### PR TITLE
Use env vars for MySQL credentials

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,8 @@
 MONGODB_URI=mongodb://127.0.0.1:27017/example_BD
 PORT=3000
 JWT_SECRET=keySecret
+
+DB_HOST=localhost
+DB_USER=user
+DB_PASSWORD=password
+DB_NAME=demodb

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.env

--- a/db.js
+++ b/db.js
@@ -1,10 +1,10 @@
 const mysql = require('mysql');
 
 const connection = mysql.createConnection({
-    host: 'minorudatabase.cvm0uaaguq3v.us-east-1.rds.amazonaws.com',
-    user: 'admin',
-    password: '12345678',
-    database: 'demodb'
+    host: process.env.DB_HOST,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME
 });
 
 connection.connect((error) => {


### PR DESCRIPTION
## Summary
- add DB credentials to `.env`
- configure `.gitignore` to ignore `.env`
- load DB connection options from environment variables

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849a5713218832d9738f171e6c307ea