### PR TITLE
Add passport initialization

### DIFF
--- a/api.js
+++ b/api.js
@@ -14,6 +14,7 @@ const getApis = require('./routes/getApis');
 const operaciones = require('./routes/operaciones')
 
 const app = express();
+app.use(passport.initialize());
 app.use(cors({
     origin: 'http://minoru-aws-demo-s3.s3-website-us-east-1.amazonaws.com',
     methods: ['GET', 'POST', 'PUT', 'DELETE'],


### PR DESCRIPTION
## Summary
- initialize passport after app creation so authentication works

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node api.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6849a71f7714832d96d84f7905fcd6f8