### PR TITLE
Implement MySQL user model and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
-MONGODB_URI=mongodb://127.0.0.1:27017/example_BD
 PORT=3000
 JWT_SECRET=keySecret
 OPERACIONES_SECRET=4RC542024L3v4n74m13n70
+CORS_ORIGIN=http://localhost:3000
 
 DB_HOST=localhost
 DB_USER=user

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # api_node
-Api en node con autenticación, tutas protegidas, upload de archivos y más ...
+Pequeña API en Node.js con autenticación por JWT, rutas protegidas,
+subida de archivos y consumo de APIs públicas.
 
 API_NODE.postman_collection.json es es la culeccion para hacer uso de la API
 
@@ -11,10 +12,10 @@ Para ejecutar la aplicación es necesario definir un archivo `.env` con las
 siguientes variables:
 
 ```
-MONGODB_URI=mongodb://127.0.0.1:27017/example_BD
 PORT=3000
 JWT_SECRET=keySecret
 OPERACIONES_SECRET=4RC542024L3v4n74m13n70
+CORS_ORIGIN=http://localhost:3000
 DB_HOST=localhost
 DB_USER=user
 DB_PASSWORD=password
@@ -23,3 +24,22 @@ DB_NAME=demodb
 
 `OPERACIONES_SECRET` se utiliza para validar los tokens manejados en el módulo
 `operacionesModule`.
+
+## Endpoints principales
+
+- `POST /auth/register` Registra un usuario.
+- `POST /auth/login` Inicia sesión y entrega un JWT.
+- `POST /auth/logout` Cierra sesión.
+- `GET /users` Obtiene todos los usuarios (protegido).
+- `POST /files/upload` Sube una imagen.
+- `POST /operaciones/suma-numeros` Retorna la suma de dos números y almacena el resultado en MySQL.
+- `GET /public-apis/get-api` Consume una API pública.
+
+## Configuración de CORS
+
+El dominio permitido se define con la variable de entorno `CORS_ORIGIN`. Si no se
+especifica se permite cualquier origen.
+
+## Pruebas
+
+Ejecuta `npm test` para correr las pruebas unitarias con Mocha.

--- a/api.js
+++ b/api.js
@@ -16,7 +16,7 @@ const operaciones = require('./routes/operaciones')
 const app = express();
 app.use(passport.initialize());
 app.use(cors({
-    origin: 'http://minoru-aws-demo-s3.s3-website-us-east-1.amazonaws.com',
+    origin: process.env.CORS_ORIGIN || '*',
     methods: ['GET', 'POST', 'PUT', 'DELETE'],
     allowedHeaders: ['Content-Type', 'Authorization']
 }));

--- a/middlewares/passport.js
+++ b/middlewares/passport.js
@@ -10,17 +10,15 @@ const jwtSecret = process.env.JWT_SECRET;
 // Configurar estrategia local para la autenticacion
 passport.use(new LocalStrategy(async (username, password, done) => {
     try {
-        console.log(username);
-        const user = await User.findOne({ username });
+        const user = await User.findByUsername(username);
         if (!user) {
             return done(null, false, { message: 'Nombre de usuario incorrecto' });
         }
         const isMatch = await bcrypt.compare(password, user.password);
         if (isMatch) {
             return done(null, user);
-        } else {
-            return done(null, false, { message: 'Contraseña incorrecta' });
         }
+        return done(null, false, { message: 'Contraseña incorrecta' });
     } catch (error) {
         return done(error);
     }

--- a/models/usersModel.js
+++ b/models/usersModel.js
@@ -1,11 +1,66 @@
-// const mongoose = require('mongoose');
+const db = require('../db');
 
-// const userSchema = new mongoose.Schema({
-//     username: String,
-//     password: String,
-//     nombre: String,
-//     correo: String,
-//     edad: Number
-// });
+const createUser = (username, password) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'INSERT INTO users (username, password) VALUES (?, ?)';
+    db.query(sql, [username, password], (err, result) => {
+      if (err) return reject(err);
+      resolve({ id: result.insertId, username });
+    });
+  });
+};
 
-// module.exports = mongoose.model('User', userSchema);
+const findByUsername = (username) => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM users WHERE username = ?', [username], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows[0]);
+    });
+  });
+};
+
+const findById = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM users WHERE id = ?', [id], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows[0]);
+    });
+  });
+};
+
+const findAll = () => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT id, username FROM users', (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+};
+
+const updateUser = (id, username) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'UPDATE users SET username = ? WHERE id = ?';
+    db.query(sql, [username, id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+const deleteUser = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('DELETE FROM users WHERE id = ?', [id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+module.exports = {
+  createUser,
+  findByUsername,
+  findById,
+  findAll,
+  updateUser,
+  deleteUser
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "body-parser": "^1.20.2",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
-        "crypto": "^1.0.1",
         "dotenv": "^16.4.1",
         "express": "^4.18.2",
         "jsonwebtoken": "^9.0.2",
@@ -325,12 +324,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
-      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
     },
     "node_modules/debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "nodemon api.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "keywords": [],
   "author": "Minoru Daniel Salazar",
@@ -16,7 +16,6 @@
     "body-parser": "^1.20.2",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
-    "crypto": "^1.0.1",
     "dotenv": "^16.4.1",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
@@ -27,6 +26,8 @@
     "passport-local": "^1.0.0"
   },
   "devDependencies": {
-    "nodemon": "^3.0.3"
+    "nodemon": "^3.0.3",
+    "mocha": "^10.2.0",
+    "chai": "^4.3.7"
   }
 }

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -12,8 +12,7 @@ router.post('/register', async (req, res, next) => {
     try {
         const { username, password } = req.body;
         const hashedPassword = await bcrypt.hash(password, 10);
-        const newUser = new User({ username, password: hashedPassword });
-        await newUser.save();
+        await User.createUser(username, hashedPassword);
         res.status(201).json({ message: 'Usuario creado exitosamente' });
     } catch (error) {
         next(error);
@@ -31,7 +30,7 @@ router.post('/login', async (req, res, next) => {
                 if (error) {
                     return next(error);
                 }
-                const token = jwt.sign({ sub: user._id }, jwtSecret);
+                const token = jwt.sign({ sub: user.id }, jwtSecret);
                 res.cookie('jwt', token, { httpOnly: true });
                 return res.status(200).json({ message: 'Autenticación exitosa', token });
             });

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,51 +1,73 @@
 const express = require('express');
 const User = require('../models/usersModel');
+const bcrypt = require('bcryptjs');
 const router = express.Router();
 
 // Ruta para obtener todos los usuarios
-// router.get('/users', async (req, res) => {
-//     const usuarios = await User.find();
-//     res.json(usuarios);
-// });
+router.get('/users', async (req, res) => {
+    try {
+        const usuarios = await User.findAll();
+        res.json(usuarios);
+    } catch (error) {
+        res.status(500).json({ message: error.message });
+    }
+});
 
 // Ruta para obtener un usuario por su ID
-// router.get('/users/:id', async (req, res) => {
-//     const { id } = req.params;
-//     const usuario = await User.findById(id);
-//     if (!usuario) {
-//         return res.status(404).json({ message: 'El usuario no existe' });
-//     }
-//     const updatedUsuario = await User.findByIdAndUpdate(id, req.body, { new: true });
-//     res.json(updatedUsuario);
-// });
+router.get('/users/:id', async (req, res) => {
+    try {
+        const { id } = req.params;
+        const usuario = await User.findById(id);
+        if (!usuario) {
+            return res.status(404).json({ message: 'El usuario no existe' });
+        }
+        res.json(usuario);
+    } catch (error) {
+        res.status(500).json({ message: error.message });
+    }
+});
 
 // Ruta para crear un nuevo usuario
-// router.post('/users', async (req, res) => {
-//     const usuario = new User(req.body);
-//     await usuario.save();
-//     res.json(usuario);
-// });
+router.post('/users', async (req, res) => {
+    try {
+        const { username, password } = req.body;
+        const hashedPassword = await bcrypt.hash(password, 10);
+        const newUser = await User.createUser(username, hashedPassword);
+        res.status(201).json(newUser);
+    } catch (error) {
+        res.status(500).json({ message: error.message });
+    }
+});
 
 // Ruta para actualizar un usuario por su ID
-// router.put('/users/:id', async (req, res) => {
-//     const { id } = req.params;
-//     const usuario = await User.findById(id);
-//     if (!usuario) {
-//         return res.status(404).json({ message: 'El usuario no existe' });
-//     }
-//     const updatedUsuario = await User.findByIdAndUpdate(id, req.body, { new: true });
-//     res.json(updatedUsuario);
-// });
+router.put('/users/:id', async (req, res) => {
+    try {
+        const { id } = req.params;
+        const { username } = req.body;
+        const usuario = await User.findById(id);
+        if (!usuario) {
+            return res.status(404).json({ message: 'El usuario no existe' });
+        }
+        await User.updateUser(id, username);
+        res.json({ message: 'Usuario actualizado' });
+    } catch (error) {
+        res.status(500).json({ message: error.message });
+    }
+});
 
 // Ruta para eliminar un usuario por su ID
-// router.delete('/users/:id', async (req, res) => {
-//     const { id } = req.params;
-//     const user = await User.findById(id);
-//     if (!user) {
-//         return res.status(404).json({ message: 'El usuario no existe' });
-//     }
-//     await User.findByIdAndDelete(id);
-//     res.status(200).json({ message: 'Usuario eliminado correctamente' });
-// });
+router.delete('/users/:id', async (req, res) => {
+    try {
+        const { id } = req.params;
+        const usuario = await User.findById(id);
+        if (!usuario) {
+            return res.status(404).json({ message: 'El usuario no existe' });
+        }
+        await User.deleteUser(id);
+        res.status(200).json({ message: 'Usuario eliminado correctamente' });
+    } catch (error) {
+        res.status(500).json({ message: error.message });
+    }
+});
 
 module.exports = router;

--- a/test/operaciones.test.js
+++ b/test/operaciones.test.js
@@ -1,0 +1,9 @@
+const { expect } = require('chai');
+const operaciones = require('../Modules/operacionesModule');
+
+describe('sumaDosNumeros', () => {
+  it('should return the sum of two numbers', async () => {
+    const result = await operaciones.sumaDosNumeros(2, 3);
+    expect(result).to.equal(5);
+  });
+});


### PR DESCRIPTION
## Summary
- replace commented mongoose model with MySQL implementation
- expose CRUD user routes using new model
- update auth and passport to use MySQL
- make allowed CORS origin configurable via env var
- document environment variables and endpoints
- add basic unit test and mocha config
- remove unused crypto dependency

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a8581e64832db273094a2cda3316