### PR TITLE
Add materials, accessories and playsets support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ DB_NAME=demodb
 - `POST /files/upload` Sube una imagen.
 - `POST /operaciones/suma-numeros` Retorna la suma de dos números y almacena el resultado en MySQL.
 - `GET /public-apis/get-api` Consume una API pública.
+- `GET /materials` Lista materiales (protegido).
+- `GET /accessories` Lista accesorios (protegido).
+- `GET /playsets` Lista playsets (protegido).
 
 ## Configuración de CORS
 

--- a/api.js
+++ b/api.js
@@ -12,6 +12,9 @@ const authRouter = require('./routes/auth');
 const filesRouter = require('./routes/files');
 const getApis = require('./routes/getApis');
 const operaciones = require('./routes/operaciones')
+const materialsRouter = require('./routes/materials');
+const accessoriesRouter = require('./routes/accessories');
+const playsetsRouter = require('./routes/playsets');
 
 const app = express();
 app.use(passport.initialize());
@@ -64,6 +67,9 @@ const authenticateJWT = (req, res, next) => {
 
 // Rutas protegidas
 app.use('/', authenticateJWT, userRouter);
+app.use('/', authenticateJWT, materialsRouter);
+app.use('/', authenticateJWT, accessoriesRouter);
+app.use('/', authenticateJWT, playsetsRouter);
 
 // Middleware para manejar errores
 app.use((err, req, res, next) => {

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS raw_materials (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS material_attributes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    material_id INT NOT NULL,
+    attribute_name VARCHAR(100) NOT NULL,
+    attribute_value VARCHAR(255),
+    FOREIGN KEY (material_id) REFERENCES raw_materials(id)
+);
+
+CREATE TABLE IF NOT EXISTS accessories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS accessory_materials (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    accessory_id INT NOT NULL,
+    material_id INT NOT NULL,
+    quantity INT,
+    FOREIGN KEY (accessory_id) REFERENCES accessories(id),
+    FOREIGN KEY (material_id) REFERENCES raw_materials(id)
+);
+
+CREATE TABLE IF NOT EXISTS playsets (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    description TEXT
+);
+
+CREATE TABLE IF NOT EXISTS playset_accessories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    playset_id INT NOT NULL,
+    accessory_id INT NOT NULL,
+    quantity INT,
+    FOREIGN KEY (playset_id) REFERENCES playsets(id),
+    FOREIGN KEY (accessory_id) REFERENCES accessories(id)
+);

--- a/models/accessoriesModel.js
+++ b/models/accessoriesModel.js
@@ -1,0 +1,56 @@
+const db = require('../db');
+
+const createAccessory = (name, description) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'INSERT INTO accessories (name, description) VALUES (?, ?)';
+    db.query(sql, [name, description], (err, result) => {
+      if (err) return reject(err);
+      resolve({ id: result.insertId, name, description });
+    });
+  });
+};
+
+const findById = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM accessories WHERE id = ?', [id], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows[0]);
+    });
+  });
+};
+
+const findAll = () => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM accessories', (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+};
+
+const updateAccessory = (id, name, description) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'UPDATE accessories SET name = ?, description = ? WHERE id = ?';
+    db.query(sql, [name, description, id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+const deleteAccessory = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('DELETE FROM accessories WHERE id = ?', [id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+module.exports = {
+  createAccessory,
+  findById,
+  findAll,
+  updateAccessory,
+  deleteAccessory
+};

--- a/models/accessoryMaterialsModel.js
+++ b/models/accessoryMaterialsModel.js
@@ -1,0 +1,56 @@
+const db = require('../db');
+
+const linkMaterial = (accessoryId, materialId, quantity) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'INSERT INTO accessory_materials (accessory_id, material_id, quantity) VALUES (?, ?, ?)';
+    db.query(sql, [accessoryId, materialId, quantity], (err, result) => {
+      if (err) return reject(err);
+      resolve({ id: result.insertId, accessoryId, materialId, quantity });
+    });
+  });
+};
+
+const findById = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM accessory_materials WHERE id = ?', [id], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows[0]);
+    });
+  });
+};
+
+const findAll = () => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM accessory_materials', (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+};
+
+const updateLink = (id, quantity) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'UPDATE accessory_materials SET quantity = ? WHERE id = ?';
+    db.query(sql, [quantity, id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+const deleteLink = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('DELETE FROM accessory_materials WHERE id = ?', [id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+module.exports = {
+  linkMaterial,
+  findById,
+  findAll,
+  updateLink,
+  deleteLink
+};

--- a/models/materialAttributesModel.js
+++ b/models/materialAttributesModel.js
@@ -1,0 +1,56 @@
+const db = require('../db');
+
+const createAttribute = (materialId, attributeName, attributeValue) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'INSERT INTO material_attributes (material_id, attribute_name, attribute_value) VALUES (?, ?, ?)';
+    db.query(sql, [materialId, attributeName, attributeValue], (err, result) => {
+      if (err) return reject(err);
+      resolve({ id: result.insertId, materialId, attributeName, attributeValue });
+    });
+  });
+};
+
+const findById = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM material_attributes WHERE id = ?', [id], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows[0]);
+    });
+  });
+};
+
+const findAll = () => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM material_attributes', (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+};
+
+const updateAttribute = (id, attributeName, attributeValue) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'UPDATE material_attributes SET attribute_name = ?, attribute_value = ? WHERE id = ?';
+    db.query(sql, [attributeName, attributeValue, id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+const deleteAttribute = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('DELETE FROM material_attributes WHERE id = ?', [id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+module.exports = {
+  createAttribute,
+  findById,
+  findAll,
+  updateAttribute,
+  deleteAttribute
+};

--- a/models/materialsModel.js
+++ b/models/materialsModel.js
@@ -1,0 +1,56 @@
+const db = require('../db');
+
+const createMaterial = (name, description) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'INSERT INTO raw_materials (name, description) VALUES (?, ?)';
+    db.query(sql, [name, description], (err, result) => {
+      if (err) return reject(err);
+      resolve({ id: result.insertId, name, description });
+    });
+  });
+};
+
+const findById = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM raw_materials WHERE id = ?', [id], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows[0]);
+    });
+  });
+};
+
+const findAll = () => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM raw_materials', (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+};
+
+const updateMaterial = (id, name, description) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'UPDATE raw_materials SET name = ?, description = ? WHERE id = ?';
+    db.query(sql, [name, description, id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+const deleteMaterial = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('DELETE FROM raw_materials WHERE id = ?', [id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+module.exports = {
+  createMaterial,
+  findById,
+  findAll,
+  updateMaterial,
+  deleteMaterial
+};

--- a/models/playsetAccessoriesModel.js
+++ b/models/playsetAccessoriesModel.js
@@ -1,0 +1,56 @@
+const db = require('../db');
+
+const linkAccessory = (playsetId, accessoryId, quantity) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'INSERT INTO playset_accessories (playset_id, accessory_id, quantity) VALUES (?, ?, ?)';
+    db.query(sql, [playsetId, accessoryId, quantity], (err, result) => {
+      if (err) return reject(err);
+      resolve({ id: result.insertId, playsetId, accessoryId, quantity });
+    });
+  });
+};
+
+const findById = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM playset_accessories WHERE id = ?', [id], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows[0]);
+    });
+  });
+};
+
+const findAll = () => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM playset_accessories', (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+};
+
+const updateLink = (id, quantity) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'UPDATE playset_accessories SET quantity = ? WHERE id = ?';
+    db.query(sql, [quantity, id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+const deleteLink = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('DELETE FROM playset_accessories WHERE id = ?', [id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+module.exports = {
+  linkAccessory,
+  findById,
+  findAll,
+  updateLink,
+  deleteLink
+};

--- a/models/playsetsModel.js
+++ b/models/playsetsModel.js
@@ -1,0 +1,56 @@
+const db = require('../db');
+
+const createPlayset = (name, description) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'INSERT INTO playsets (name, description) VALUES (?, ?)';
+    db.query(sql, [name, description], (err, result) => {
+      if (err) return reject(err);
+      resolve({ id: result.insertId, name, description });
+    });
+  });
+};
+
+const findById = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM playsets WHERE id = ?', [id], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows[0]);
+    });
+  });
+};
+
+const findAll = () => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM playsets', (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+};
+
+const updatePlayset = (id, name, description) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'UPDATE playsets SET name = ?, description = ? WHERE id = ?';
+    db.query(sql, [name, description, id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+const deletePlayset = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('DELETE FROM playsets WHERE id = ?', [id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+module.exports = {
+  createPlayset,
+  findById,
+  findAll,
+  updatePlayset,
+  deletePlayset
+};

--- a/routes/accessories.js
+++ b/routes/accessories.js
@@ -1,0 +1,57 @@
+const express = require('express');
+const Accessories = require('../models/accessoriesModel');
+const router = express.Router();
+
+router.get('/accessories', async (req, res) => {
+  try {
+    const accessories = await Accessories.findAll();
+    res.json(accessories);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.get('/accessories/:id', async (req, res) => {
+  try {
+    const accessory = await Accessories.findById(req.params.id);
+    if (!accessory) return res.status(404).json({ message: 'Accesorio no encontrado' });
+    res.json(accessory);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.post('/accessories', async (req, res) => {
+  try {
+    const { name, description } = req.body;
+    const accessory = await Accessories.createAccessory(name, description);
+    res.status(201).json(accessory);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.put('/accessories/:id', async (req, res) => {
+  try {
+    const { name, description } = req.body;
+    const accessory = await Accessories.findById(req.params.id);
+    if (!accessory) return res.status(404).json({ message: 'Accesorio no encontrado' });
+    await Accessories.updateAccessory(req.params.id, name, description);
+    res.json({ message: 'Accesorio actualizado' });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.delete('/accessories/:id', async (req, res) => {
+  try {
+    const accessory = await Accessories.findById(req.params.id);
+    if (!accessory) return res.status(404).json({ message: 'Accesorio no encontrado' });
+    await Accessories.deleteAccessory(req.params.id);
+    res.json({ message: 'Accesorio eliminado' });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+module.exports = router;

--- a/routes/materials.js
+++ b/routes/materials.js
@@ -1,0 +1,57 @@
+const express = require('express');
+const Materials = require('../models/materialsModel');
+const router = express.Router();
+
+router.get('/materials', async (req, res) => {
+  try {
+    const materials = await Materials.findAll();
+    res.json(materials);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.get('/materials/:id', async (req, res) => {
+  try {
+    const material = await Materials.findById(req.params.id);
+    if (!material) return res.status(404).json({ message: 'Material no encontrado' });
+    res.json(material);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.post('/materials', async (req, res) => {
+  try {
+    const { name, description } = req.body;
+    const material = await Materials.createMaterial(name, description);
+    res.status(201).json(material);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.put('/materials/:id', async (req, res) => {
+  try {
+    const { name, description } = req.body;
+    const material = await Materials.findById(req.params.id);
+    if (!material) return res.status(404).json({ message: 'Material no encontrado' });
+    await Materials.updateMaterial(req.params.id, name, description);
+    res.json({ message: 'Material actualizado' });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.delete('/materials/:id', async (req, res) => {
+  try {
+    const material = await Materials.findById(req.params.id);
+    if (!material) return res.status(404).json({ message: 'Material no encontrado' });
+    await Materials.deleteMaterial(req.params.id);
+    res.json({ message: 'Material eliminado' });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+module.exports = router;

--- a/routes/playsets.js
+++ b/routes/playsets.js
@@ -1,0 +1,57 @@
+const express = require('express');
+const Playsets = require('../models/playsetsModel');
+const router = express.Router();
+
+router.get('/playsets', async (req, res) => {
+  try {
+    const playsets = await Playsets.findAll();
+    res.json(playsets);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.get('/playsets/:id', async (req, res) => {
+  try {
+    const playset = await Playsets.findById(req.params.id);
+    if (!playset) return res.status(404).json({ message: 'Playset no encontrado' });
+    res.json(playset);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.post('/playsets', async (req, res) => {
+  try {
+    const { name, description } = req.body;
+    const playset = await Playsets.createPlayset(name, description);
+    res.status(201).json(playset);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.put('/playsets/:id', async (req, res) => {
+  try {
+    const { name, description } = req.body;
+    const playset = await Playsets.findById(req.params.id);
+    if (!playset) return res.status(404).json({ message: 'Playset no encontrado' });
+    await Playsets.updatePlayset(req.params.id, name, description);
+    res.json({ message: 'Playset actualizado' });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.delete('/playsets/:id', async (req, res) => {
+  try {
+    const playset = await Playsets.findById(req.params.id);
+    if (!playset) return res.status(404).json({ message: 'Playset no encontrado' });
+    await Playsets.deletePlayset(req.params.id);
+    res.json({ message: 'Playset eliminado' });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+module.exports = router;

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -1,0 +1,24 @@
+const { expect } = require('chai');
+const materials = require('../models/materialsModel');
+const accessories = require('../models/accessoriesModel');
+const playsets = require('../models/playsetsModel');
+
+describe('Model exports', () => {
+  it('materials model exposes CRUD functions', () => {
+    expect(materials.createMaterial).to.be.a('function');
+    expect(materials.findById).to.be.a('function');
+    expect(materials.findAll).to.be.a('function');
+  });
+
+  it('accessories model exposes CRUD functions', () => {
+    expect(accessories.createAccessory).to.be.a('function');
+    expect(accessories.findById).to.be.a('function');
+    expect(accessories.findAll).to.be.a('function');
+  });
+
+  it('playsets model exposes CRUD functions', () => {
+    expect(playsets.createPlayset).to.be.a('function');
+    expect(playsets.findById).to.be.a('function');
+    expect(playsets.findAll).to.be.a('function');
+  });
+});

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -1,0 +1,18 @@
+const { expect } = require('chai');
+const materialsRouter = require('../routes/materials');
+const accessoriesRouter = require('../routes/accessories');
+const playsetsRouter = require('../routes/playsets');
+
+describe('Route definitions', () => {
+  it('materials router has routes configured', () => {
+    expect(materialsRouter.stack).to.be.an('array').that.is.not.empty;
+  });
+
+  it('accessories router has routes configured', () => {
+    expect(accessoriesRouter.stack).to.be.an('array').that.is.not.empty;
+  });
+
+  it('playsets router has routes configured', () => {
+    expect(playsetsRouter.stack).to.be.an('array').that.is.not.empty;
+  });
+});


### PR DESCRIPTION
## Summary
- add SQL script to create materials, accessories and playsets tables
- implement models for all new entities
- expose CRUD routes for `/materials`, `/accessories` and `/playsets`
- register new routers in the main API file
- add basic unit tests
- document new endpoints in README

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b6e7fdd0832dbdb851ab22a5408c