### PR TITLE
Add scenario routes and collection

### DIFF
--- a/API_NODE_Scenario.postman_collection.json
+++ b/API_NODE_Scenario.postman_collection.json
@@ -1,0 +1,168 @@
+{
+  "info": {
+    "name": "API_NODE_SCENARIO",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Login",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"username\": \"{{user}}\",\n  \"password\": \"{{password}}\"\n}",
+          "options": {"raw": {"language": "json"}}
+        },
+        "url": {
+          "raw": "http://localhost:3000/auth/login",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["auth","login"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Create Wood Board",
+      "request": {
+        "method": "POST",
+        "header": [{"key":"Authorization","value":"Bearer {{token}}"}],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"name\": \"Tabla de madera\",\n  \"description\": \"Madera 16mm 1.22x2.44m costo 1000\"\n}",
+          "options": {"raw": {"language":"json"}}
+        },
+        "url": {
+          "raw": "http://localhost:3000/materials",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["materials"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Create Tornillo",
+      "request": {
+        "method": "POST",
+        "header": [{"key":"Authorization","value":"Bearer {{token}}"}],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"name\": \"Tornillo cabeza de coche\",\n  \"description\": \"1 1/2 pulgada calibre 1/4 costo 5\"\n}",
+          "options": {"raw": {"language":"json"}}
+        },
+        "url": {
+          "raw": "http://localhost:3000/materials",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["materials"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Create Vinil",
+      "request": {
+        "method": "POST",
+        "header": [{"key":"Authorization","value":"Bearer {{token}}"}],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"name\": \"Vinil 18oz\",\n  \"description\": \"Rollo 60m x 1.50m costo 6000\"\n}",
+          "options": {"raw": {"language":"json"}}
+        },
+        "url": {
+          "raw": "http://localhost:3000/materials",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["materials"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Create Accessory",
+      "request": {
+        "method": "POST",
+        "header": [{"key":"Authorization","value":"Bearer {{token}}"}],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"name\": \"Accesorio ejemplo\",\n  \"description\": \"Pieza de tabla 30x40 cm, 20 tornillos y vinil 60x70 cm\"\n}",
+          "options": {"raw": {"language":"json"}}
+        },
+        "url": {
+          "raw": "http://localhost:3000/accessories",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["accessories"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Link Wood Board",
+      "request": {
+        "method": "POST",
+        "header": [{"key":"Authorization","value":"Bearer {{token}}"}],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"accessoryId\": 1,\n  \"materialId\": 1,\n  \"quantity\": 1\n}",
+          "options": {"raw": {"language":"json"}}
+        },
+        "url": {
+          "raw": "http://localhost:3000/accessory-materials",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["accessory-materials"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Link Screws",
+      "request": {
+        "method": "POST",
+        "header": [{"key":"Authorization","value":"Bearer {{token}}"}],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"accessoryId\": 1,\n  \"materialId\": 2,\n  \"quantity\": 20\n}",
+          "options": {"raw": {"language":"json"}}
+        },
+        "url": {
+          "raw": "http://localhost:3000/accessory-materials",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["accessory-materials"]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Link Vinyl",
+      "request": {
+        "method": "POST",
+        "header": [{"key":"Authorization","value":"Bearer {{token}}"}],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"accessoryId\": 1,\n  \"materialId\": 3,\n  \"quantity\": 1\n}",
+          "options": {"raw": {"language":"json"}}
+        },
+        "url": {
+          "raw": "http://localhost:3000/accessory-materials",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["accessory-materials"]
+        }
+      },
+      "response": []
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Pequeña API en Node.js con autenticación por JWT, rutas protegidas,
 subida de archivos y consumo de APIs públicas.
 
-API_NODE_New.postman_collection.json es la colección actualizada para usar la API, incluyendo materiales, accesorios y playsets.
+API_NODE_New.postman_collection.json es la colección actualizada para usar la API, incluyendo materiales, accesorios y playsets. Para el escenario de ejemplo se agregó el archivo `API_NODE_Scenario.postman_collection.json` que muestra cómo registrar materiales y vincularlos a un accesorio.
 
 y el examen teorico es el archivo word cuestionarioNode.dox
 

--- a/api.js
+++ b/api.js
@@ -15,6 +15,8 @@ const operaciones = require('./routes/operaciones')
 const materialsRouter = require('./routes/materials');
 const accessoriesRouter = require('./routes/accessories');
 const playsetsRouter = require('./routes/playsets');
+const materialAttributesRouter = require('./routes/materialAttributes');
+const accessoryMaterialsRouter = require('./routes/accessoryMaterials');
 
 const app = express();
 app.use(passport.initialize());
@@ -70,6 +72,8 @@ app.use('/', authenticateJWT, userRouter);
 app.use('/', authenticateJWT, materialsRouter);
 app.use('/', authenticateJWT, accessoriesRouter);
 app.use('/', authenticateJWT, playsetsRouter);
+app.use('/', authenticateJWT, materialAttributesRouter);
+app.use('/', authenticateJWT, accessoryMaterialsRouter);
 
 // Middleware para manejar errores
 app.use((err, req, res, next) => {

--- a/routes/accessoryMaterials.js
+++ b/routes/accessoryMaterials.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const AccessoryMaterials = require('../models/accessoryMaterialsModel');
+const router = express.Router();
+
+router.post('/accessory-materials', async (req, res) => {
+  try {
+    const { accessoryId, materialId, quantity } = req.body;
+    const link = await AccessoryMaterials.linkMaterial(accessoryId, materialId, quantity);
+    res.status(201).json(link);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.get('/accessory-materials', async (req, res) => {
+  try {
+    const links = await AccessoryMaterials.findAll();
+    res.json(links);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+module.exports = router;

--- a/routes/materialAttributes.js
+++ b/routes/materialAttributes.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const MaterialAttributes = require('../models/materialAttributesModel');
+const router = express.Router();
+
+router.post('/material-attributes', async (req, res) => {
+  try {
+    const { materialId, attributeName, attributeValue } = req.body;
+    const attribute = await MaterialAttributes.createAttribute(materialId, attributeName, attributeValue);
+    res.status(201).json(attribute);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.get('/material-attributes', async (req, res) => {
+  try {
+    const attrs = await MaterialAttributes.findAll();
+    res.json(attrs);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+module.exports = router;

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -2,6 +2,8 @@ const { expect } = require('chai');
 const materialsRouter = require('../routes/materials');
 const accessoriesRouter = require('../routes/accessories');
 const playsetsRouter = require('../routes/playsets');
+const materialAttributesRouter = require('../routes/materialAttributes');
+const accessoryMaterialsRouter = require('../routes/accessoryMaterials');
 
 describe('Route definitions', () => {
   it('materials router has routes configured', () => {
@@ -14,5 +16,13 @@ describe('Route definitions', () => {
 
   it('playsets router has routes configured', () => {
     expect(playsetsRouter.stack).to.be.an('array').that.is.not.empty;
+  });
+
+  it('material attributes router has routes configured', () => {
+    expect(materialAttributesRouter.stack).to.be.an('array').that.is.not.empty;
+  });
+
+  it('accessory materials router has routes configured', () => {
+    expect(accessoryMaterialsRouter.stack).to.be.an('array').that.is.not.empty;
   });
 });


### PR DESCRIPTION
## Summary
- add routes to manage material attributes and accessory materials
- wire new routes in `api.js`
- extend router tests
- document new Postman collection in README
- provide example collection `API_NODE_Scenario.postman_collection.json`

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849beaf9b7c832db3db0bea8074b772