### PR TITLE
Add material details and cost calculator

### DIFF
--- a/API_NODE_Scenario.postman_collection.json
+++ b/API_NODE_Scenario.postman_collection.json
@@ -31,7 +31,7 @@
         "header": [{"key":"Authorization","value":"Bearer {{token}}"}],
         "body": {
           "mode": "raw",
-          "raw": "{\n  \"name\": \"Tabla de madera\",\n  \"description\": \"Madera 16mm 1.22x2.44m costo 1000\"\n}",
+          "raw": "{\n  \"name\": \"Tabla de madera\",\n  \"description\": \"Madera 16mm 1.22x2.44m costo 1000\",\n  \"thickness_mm\": 16,\n  \"width_m\": 1.22,\n  \"length_m\": 2.44,\n  \"price\": 1000\n}",
           "options": {"raw": {"language":"json"}}
         },
         "url": {
@@ -51,7 +51,7 @@
         "header": [{"key":"Authorization","value":"Bearer {{token}}"}],
         "body": {
           "mode": "raw",
-          "raw": "{\n  \"name\": \"Tornillo cabeza de coche\",\n  \"description\": \"1 1/2 pulgada calibre 1/4 costo 5\"\n}",
+          "raw": "{\n  \"name\": \"Tornillo cabeza de coche\",\n  \"description\": \"1 1/2 pulgada calibre 1/4 costo 5\",\n  \"thickness_mm\": 6,\n  \"width_m\": 0.006,\n  \"length_m\": 0.038,\n  \"price\": 5\n}",
           "options": {"raw": {"language":"json"}}
         },
         "url": {
@@ -71,7 +71,7 @@
         "header": [{"key":"Authorization","value":"Bearer {{token}}"}],
         "body": {
           "mode": "raw",
-          "raw": "{\n  \"name\": \"Vinil 18oz\",\n  \"description\": \"Rollo 60m x 1.50m costo 6000\"\n}",
+          "raw": "{\n  \"name\": \"Vinil 18oz\",\n  \"description\": \"Rollo 60m x 1.50m costo 6000\",\n  \"thickness_mm\": 1,\n  \"width_m\": 1.5,\n  \"length_m\": 60,\n  \"price\": 6000\n}",
           "options": {"raw": {"language":"json"}}
         },
         "url": {
@@ -111,7 +111,7 @@
         "header": [{"key":"Authorization","value":"Bearer {{token}}"}],
         "body": {
           "mode": "raw",
-          "raw": "{\n  \"accessoryId\": 1,\n  \"materialId\": 1,\n  \"quantity\": 1\n}",
+          "raw": "{\n  \"accessoryId\": 1,\n  \"materialId\": 1,\n  \"quantity\": 1,\n  \"width\": 0.3,\n  \"length\": 0.4\n}",
           "options": {"raw": {"language":"json"}}
         },
         "url": {

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -1,7 +1,11 @@
 CREATE TABLE IF NOT EXISTS raw_materials (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
-    description TEXT
+    description TEXT,
+    thickness_mm DECIMAL(10,2),
+    width_m DECIMAL(10,2),
+    length_m DECIMAL(10,2),
+    price DECIMAL(10,2)
 );
 
 CREATE TABLE IF NOT EXISTS material_attributes (

--- a/models/accessoryMaterialsModel.js
+++ b/models/accessoryMaterialsModel.js
@@ -10,6 +10,22 @@ const linkMaterial = (accessoryId, materialId, quantity) => {
   });
 };
 
+const calculateCost = (materialId, width, length, quantity = 1) => {
+  return new Promise((resolve, reject) => {
+    const sql =
+      'SELECT width_m, length_m, price FROM raw_materials WHERE id = ?';
+    db.query(sql, [materialId], (err, rows) => {
+      if (err) return reject(err);
+      if (rows.length === 0) return reject(new Error('Material not found'));
+      const material = rows[0];
+      const fullArea = material.width_m * material.length_m;
+      const pieceArea = width * length;
+      const unitCost = (material.price / fullArea) * pieceArea;
+      resolve(unitCost * quantity);
+    });
+  });
+};
+
 const findById = (id) => {
   return new Promise((resolve, reject) => {
     db.query('SELECT * FROM accessory_materials WHERE id = ?', [id], (err, rows) => {
@@ -52,5 +68,6 @@ module.exports = {
   findById,
   findAll,
   updateLink,
-  deleteLink
+  deleteLink,
+  calculateCost
 };

--- a/models/materialsModel.js
+++ b/models/materialsModel.js
@@ -1,12 +1,25 @@
 const db = require('../db');
 
-const createMaterial = (name, description) => {
+const createMaterial = (name, description, thickness, width, length, price) => {
   return new Promise((resolve, reject) => {
-    const sql = 'INSERT INTO raw_materials (name, description) VALUES (?, ?)';
-    db.query(sql, [name, description], (err, result) => {
-      if (err) return reject(err);
-      resolve({ id: result.insertId, name, description });
-    });
+    const sql =
+      'INSERT INTO raw_materials (name, description, thickness_mm, width_m, length_m, price) VALUES (?, ?, ?, ?, ?, ?)';
+    db.query(
+      sql,
+      [name, description, thickness, width, length, price],
+      (err, result) => {
+        if (err) return reject(err);
+        resolve({
+          id: result.insertId,
+          name,
+          description,
+          thickness_mm: thickness,
+          width_m: width,
+          length_m: length,
+          price
+        });
+      }
+    );
   });
 };
 
@@ -28,13 +41,26 @@ const findAll = () => {
   });
 };
 
-const updateMaterial = (id, name, description) => {
+const updateMaterial = (
+  id,
+  name,
+  description,
+  thickness,
+  width,
+  length,
+  price
+) => {
   return new Promise((resolve, reject) => {
-    const sql = 'UPDATE raw_materials SET name = ?, description = ? WHERE id = ?';
-    db.query(sql, [name, description, id], (err, result) => {
-      if (err) return reject(err);
-      resolve(result);
-    });
+    const sql =
+      'UPDATE raw_materials SET name = ?, description = ?, thickness_mm = ?, width_m = ?, length_m = ?, price = ? WHERE id = ?';
+    db.query(
+      sql,
+      [name, description, thickness, width, length, price, id],
+      (err, result) => {
+        if (err) return reject(err);
+        resolve(result);
+      }
+    );
   });
 };
 

--- a/routes/accessoryMaterials.js
+++ b/routes/accessoryMaterials.js
@@ -4,9 +4,19 @@ const router = express.Router();
 
 router.post('/accessory-materials', async (req, res) => {
   try {
-    const { accessoryId, materialId, quantity } = req.body;
-    const link = await AccessoryMaterials.linkMaterial(accessoryId, materialId, quantity);
-    res.status(201).json(link);
+    const { accessoryId, materialId, quantity, width, length } = req.body;
+    const link = await AccessoryMaterials.linkMaterial(
+      accessoryId,
+      materialId,
+      quantity
+    );
+    const cost = await AccessoryMaterials.calculateCost(
+      materialId,
+      width,
+      length,
+      quantity
+    );
+    res.status(201).json({ ...link, cost });
   } catch (error) {
     res.status(500).json({ message: error.message });
   }

--- a/routes/materials.js
+++ b/routes/materials.js
@@ -23,8 +23,22 @@ router.get('/materials/:id', async (req, res) => {
 
 router.post('/materials', async (req, res) => {
   try {
-    const { name, description } = req.body;
-    const material = await Materials.createMaterial(name, description);
+    const {
+      name,
+      description,
+      thickness_mm,
+      width_m,
+      length_m,
+      price
+    } = req.body;
+    const material = await Materials.createMaterial(
+      name,
+      description,
+      thickness_mm,
+      width_m,
+      length_m,
+      price
+    );
     res.status(201).json(material);
   } catch (error) {
     res.status(500).json({ message: error.message });
@@ -33,10 +47,26 @@ router.post('/materials', async (req, res) => {
 
 router.put('/materials/:id', async (req, res) => {
   try {
-    const { name, description } = req.body;
+    const {
+      name,
+      description,
+      thickness_mm,
+      width_m,
+      length_m,
+      price
+    } = req.body;
     const material = await Materials.findById(req.params.id);
-    if (!material) return res.status(404).json({ message: 'Material no encontrado' });
-    await Materials.updateMaterial(req.params.id, name, description);
+    if (!material)
+      return res.status(404).json({ message: 'Material no encontrado' });
+    await Materials.updateMaterial(
+      req.params.id,
+      name,
+      description,
+      thickness_mm,
+      width_m,
+      length_m,
+      price
+    );
     res.json({ message: 'Material actualizado' });
   } catch (error) {
     res.status(500).json({ message: error.message });


### PR DESCRIPTION
## Summary
- extend database schema with material dimensions and price
- support new fields in materials model and routes
- add cost calculation helper when linking materials to accessories
- return calculated cost from accessory-material link route
- update Postman scenario with new fields and example cost calculation

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c2c94048832dad097b3bcb6ee45b