### PR TITLE
Add unit tests for material creation and cost calculation

### DIFF
--- a/test/models.test.js
+++ b/test/models.test.js
@@ -22,3 +22,57 @@ describe('Model exports', () => {
     expect(playsets.findAll).to.be.a('function');
   });
 });
+
+describe('Model logic', () => {
+  const db = require('../db');
+  const accessoryMaterials = require('../models/accessoryMaterialsModel');
+  let originalQuery;
+
+  beforeEach(() => {
+    originalQuery = db.query;
+  });
+
+  afterEach(() => {
+    db.query = originalQuery;
+  });
+
+  it('createMaterial returns created material with all fields', async () => {
+    db.query = (sql, params, callback) => {
+      callback(null, { insertId: 1 });
+    };
+
+    const result = await materials.createMaterial(
+      'Wood',
+      'Pine wood',
+      5,
+      2,
+      3,
+      20
+    );
+
+    expect(result).to.deep.equal({
+      id: 1,
+      name: 'Wood',
+      description: 'Pine wood',
+      thickness_mm: 5,
+      width_m: 2,
+      length_m: 3,
+      price: 20
+    });
+  });
+
+  it('calculateCost computes correct cost based on material dimensions', async () => {
+    db.query = (sql, params, callback) => {
+      callback(null, [{ width_m: 2, length_m: 3, price: 12 }]);
+    };
+
+    const cost = await accessoryMaterials.calculateCost(1, 1, 1.5, 2);
+
+    // fullArea = 2 * 3 = 6
+    // pieceArea = 1 * 1.5 = 1.5
+    // unitCost = (12 / 6) * 1.5 = 3
+    // total cost = 3 * 2 = 6
+    expect(cost).to.be.closeTo(6, 0.0001);
+  });
+});
+


### PR DESCRIPTION
## Summary
- expand `models.test.js` with more model logic tests
- mock database calls to test `createMaterial` and `calculateCost`

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c93ed6f8832d906555b6e6407089