### PR TITLE
Add material segment calculations

### DIFF
--- a/models/accessoryMaterialsModel.js
+++ b/models/accessoryMaterialsModel.js
@@ -26,6 +26,20 @@ const calculateCost = (materialId, width, length, quantity = 1) => {
   });
 };
 
+const calculateSegment = (materialId, width, length, quantity = 1) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'SELECT width_m FROM raw_materials WHERE id = ?';
+    db.query(sql, [materialId], (err, rows) => {
+      if (err) return reject(err);
+      if (rows.length === 0) return reject(new Error('Material not found'));
+      const materialWidth = rows[0].width_m;
+      const pieceArea = width * length;
+      const segmentLength = (pieceArea / materialWidth) * quantity;
+      resolve(segmentLength);
+    });
+  });
+};
+
 const findById = (id) => {
   return new Promise((resolve, reject) => {
     db.query('SELECT * FROM accessory_materials WHERE id = ?', [id], (err, rows) => {
@@ -69,5 +83,6 @@ module.exports = {
   findAll,
   updateLink,
   deleteLink,
-  calculateCost
+  calculateCost,
+  calculateSegment
 };

--- a/routes/accessoryMaterials.js
+++ b/routes/accessoryMaterials.js
@@ -16,7 +16,13 @@ router.post('/accessory-materials', async (req, res) => {
       length,
       quantity
     );
-    res.status(201).json({ ...link, cost });
+    const segment = await AccessoryMaterials.calculateSegment(
+      materialId,
+      width,
+      length,
+      quantity
+    );
+    res.status(201).json({ ...link, cost, segment });
   } catch (error) {
     res.status(500).json({ message: error.message });
   }

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -74,5 +74,17 @@ describe('Model logic', () => {
     // total cost = 3 * 2 = 6
     expect(cost).to.be.closeTo(6, 0.0001);
   });
+
+  it('calculateSegment returns used length based on material width', async () => {
+    db.query = (sql, params, callback) => {
+      callback(null, [{ width_m: 2 }]);
+    };
+
+    const segment = await accessoryMaterials.calculateSegment(1, 1, 1.5, 2);
+
+    // pieceArea = 1 * 1.5 = 1.5
+    // segmentLength = (1.5 / 2) * 2 = 1.5
+    expect(segment).to.be.closeTo(1.5, 0.0001);
+  });
 });
 


### PR DESCRIPTION
## Summary
- compute material segment for accessory materials based on piece area
- expose segment calculation in API response
- add unit test for `calculateSegment`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849cf617fc0832d90f3d08511d65983