### PR TITLE
Add accessory cost endpoint and update collections

### DIFF
--- a/API_NODE_New.postman_collection.json
+++ b/API_NODE_New.postman_collection.json
@@ -133,6 +133,21 @@
           "response": []
         },
         {
+          "name": "Accessories Materials Cost",
+          "request": {
+            "method": "GET",
+            "header": [{"key": "Authorization", "value": "Bearer {{token}}"}],
+            "url": {
+              "raw": "http://localhost:3000/accessories/materials-cost",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["accessories", "materials-cost"]
+            }
+          },
+          "response": []
+        },
+        {
           "name": "Create Accessory",
           "request": {
             "method": "POST",

--- a/API_NODE_Scenario.postman_collection.json
+++ b/API_NODE_Scenario.postman_collection.json
@@ -175,6 +175,21 @@
           "body": "{\n  \"id\": 3,\n  \"accessoryId\": 1,\n  \"materialId\": 3,\n  \"quantity\": 1,\n  \"cost\": 28,\n  \"segment\": {\n    \"width\": 0.6,\n    \"length\": 0.7\n  }\n}"
         }
       ]
+    },
+    {
+      "name": "Accessories Materials Cost",
+      "request": {
+        "method": "GET",
+        "header": [{"key": "Authorization", "value": "Bearer {{token}}"}],
+        "url": {
+          "raw": "http://localhost:3000/accessories/materials-cost",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["accessories", "materials-cost"]
+        }
+      },
+      "response": []
     }
   ]
 }

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -27,6 +27,8 @@ CREATE TABLE IF NOT EXISTS accessory_materials (
     accessory_id INT NOT NULL,
     material_id INT NOT NULL,
     quantity INT,
+    width_m DECIMAL(10,2),
+    length_m DECIMAL(10,2),
     FOREIGN KEY (accessory_id) REFERENCES accessories(id),
     FOREIGN KEY (material_id) REFERENCES raw_materials(id)
 );

--- a/models/accessoryMaterialsModel.js
+++ b/models/accessoryMaterialsModel.js
@@ -1,12 +1,17 @@
 const db = require('../db');
 
-const linkMaterial = (accessoryId, materialId, quantity) => {
+const linkMaterial = (accessoryId, materialId, quantity, width, length) => {
   return new Promise((resolve, reject) => {
-    const sql = 'INSERT INTO accessory_materials (accessory_id, material_id, quantity) VALUES (?, ?, ?)';
-    db.query(sql, [accessoryId, materialId, quantity], (err, result) => {
-      if (err) return reject(err);
-      resolve({ id: result.insertId, accessoryId, materialId, quantity });
-    });
+    const sql =
+      'INSERT INTO accessory_materials (accessory_id, material_id, quantity, width_m, length_m) VALUES (?, ?, ?, ?, ?)';
+    db.query(
+      sql,
+      [accessoryId, materialId, quantity, width, length],
+      (err, result) => {
+        if (err) return reject(err);
+        resolve({ id: result.insertId, accessoryId, materialId, quantity, width, length });
+      }
+    );
   });
 };
 
@@ -44,6 +49,42 @@ const findAll = () => {
   });
 };
 
+const findAccessoriesWithMaterialsCost = () => {
+  return new Promise((resolve, reject) => {
+    const sql = `
+      SELECT a.id AS accessory_id, a.name AS accessory_name,
+             am.quantity, am.width_m AS piece_width, am.length_m AS piece_length,
+             rm.id AS material_id, rm.name AS material_name,
+             rm.price, rm.width_m AS material_width, rm.length_m AS material_length
+      FROM accessories a
+      JOIN accessory_materials am ON a.id = am.accessory_id
+      JOIN raw_materials rm ON rm.id = am.material_id`;
+    db.query(sql, (err, rows) => {
+      if (err) return reject(err);
+      const detailed = rows.map((row) => {
+        let cost = row.price * row.quantity;
+        if (row.piece_width && row.piece_length) {
+          const fullArea = row.material_width * row.material_length;
+          const pieceArea = row.piece_width * row.piece_length;
+          const unitCost = (row.price / fullArea) * pieceArea;
+          cost = unitCost * row.quantity;
+        }
+        return {
+          accessory_id: row.accessory_id,
+          accessory_name: row.accessory_name,
+          material_id: row.material_id,
+          material_name: row.material_name,
+          quantity: row.quantity,
+          width_m: row.piece_width,
+          length_m: row.piece_length,
+          cost
+        };
+      });
+      resolve(detailed);
+    });
+  });
+};
+
 const updateLink = (id, quantity) => {
   return new Promise((resolve, reject) => {
     const sql = 'UPDATE accessory_materials SET quantity = ? WHERE id = ?';
@@ -67,6 +108,7 @@ module.exports = {
   linkMaterial,
   findById,
   findAll,
+  findAccessoriesWithMaterialsCost,
   updateLink,
   deleteLink,
   calculateCost

--- a/routes/accessoryMaterials.js
+++ b/routes/accessoryMaterials.js
@@ -8,7 +8,9 @@ router.post('/accessory-materials', async (req, res) => {
     const link = await AccessoryMaterials.linkMaterial(
       accessoryId,
       materialId,
-      quantity
+      quantity,
+      width,
+      length
     );
     const cost = await AccessoryMaterials.calculateCost(
       materialId,
@@ -26,6 +28,33 @@ router.get('/accessory-materials', async (req, res) => {
   try {
     const links = await AccessoryMaterials.findAll();
     res.json(links);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.get('/accessories/materials-cost', async (req, res) => {
+  try {
+    const rows = await AccessoryMaterials.findAccessoriesWithMaterialsCost();
+    const grouped = {};
+    rows.forEach((row) => {
+      if (!grouped[row.accessory_id]) {
+        grouped[row.accessory_id] = {
+          accessory_id: row.accessory_id,
+          accessory_name: row.accessory_name,
+          materials: []
+        };
+      }
+      grouped[row.accessory_id].materials.push({
+        material_id: row.material_id,
+        material_name: row.material_name,
+        quantity: row.quantity,
+        width_m: row.width_m,
+        length_m: row.length_m,
+        cost: row.cost
+      });
+    });
+    res.json(Object.values(grouped));
   } catch (error) {
     res.status(500).json({ message: error.message });
   }


### PR DESCRIPTION
## Summary
- store width and length in accessory_materials table
- compute accessory material costs
- expose `GET /accessories/materials-cost`
- update Postman collections

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d388e558832db04074b25eb6fecf