### PR TITLE
Add playset accessories routes

### DIFF
--- a/API_NODE.postman_collection.json
+++ b/API_NODE.postman_collection.json
@@ -378,6 +378,23 @@
 				}
 			},
 			"response": []
-		}
-	]
+                },
+                {
+                        "name": "List Playset Accessories",
+                        "request": {
+                                "method": "GET",
+                                "header": [
+                                        {"key": "Authorization", "value": "Bearer {{token}}"}
+                                ],
+                                "url": {
+                                        "raw": "http://localhost:3000/playset-accessories",
+                                        "protocol": "http",
+                                        "host": ["localhost"],
+                                        "port": "3000",
+                                        "path": ["playset-accessories"]
+                                }
+                        },
+                        "response": []
+                }
+        ]
 }

--- a/API_NODE_New.postman_collection.json
+++ b/API_NODE_New.postman_collection.json
@@ -266,6 +266,26 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "Playset Accessories",
+      "item": [
+        {
+          "name": "List Playset Accessories",
+          "request": {
+            "method": "GET",
+            "header": [{"key": "Authorization", "value": "Bearer {{token}}"}],
+            "url": {
+              "raw": "http://localhost:3000/playset-accessories",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["playset-accessories"]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ]
 }

--- a/API_NODE_Scenario.postman_collection.json
+++ b/API_NODE_Scenario.postman_collection.json
@@ -191,6 +191,22 @@
         }
       },
       "response": []
+    },
+    {
+      "name": "List Playset Accessories",
+      "request": {
+        "method": "GET",
+        "header": [{"key": "Authorization", "value": "Bearer {{token}}"}],
+        "url": {
+          "raw": "http://localhost:3000/playset-accessories",
+          "protocol": "http",
+          "host": ["localhost"],
+          "port": "3000",
+          "path": ["playset-accessories"]
+
+        }
+      },
+      "response": []
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ DB_NAME=demodb
 - `GET /materials` Lista materiales (protegido).
 - `GET /accessories` Lista accesorios (protegido).
 - `GET /playsets` Lista playsets (protegido).
+- `POST /playset-accessories` Crea vínculo de accesorio a playset (protegido).
+- `GET /playset-accessories` Lista vínculos playset-accesorio (protegido).
+- `PUT /playset-accessories/:id` Actualiza la cantidad del vínculo (protegido).
+- `DELETE /playset-accessories/:id` Elimina un vínculo (protegido).
 
 ## Configuración de CORS
 

--- a/api.js
+++ b/api.js
@@ -15,6 +15,7 @@ const operaciones = require('./routes/operaciones')
 const materialsRouter = require('./routes/materials');
 const accessoriesRouter = require('./routes/accessories');
 const playsetsRouter = require('./routes/playsets');
+const playsetAccessoriesRouter = require('./routes/playsetAccessories');
 const materialAttributesRouter = require('./routes/materialAttributes');
 const accessoryMaterialsRouter = require('./routes/accessoryMaterials');
 
@@ -73,6 +74,7 @@ app.use('/', authenticateJWT, materialsRouter);
 app.use('/', authenticateJWT, accessoryMaterialsRouter);
 app.use('/', authenticateJWT, accessoriesRouter);
 app.use('/', authenticateJWT, playsetsRouter);
+app.use('/', authenticateJWT, playsetAccessoriesRouter);
 app.use('/', authenticateJWT, materialAttributesRouter);
 
 // Middleware para manejar errores

--- a/routes/playsetAccessories.js
+++ b/routes/playsetAccessories.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const PlaysetAccessories = require('../models/playsetAccessoriesModel');
+const router = express.Router();
+
+// Create link between playset and accessory
+router.post('/playset-accessories', async (req, res) => {
+  try {
+    const { playsetId, accessoryId, quantity } = req.body;
+    const link = await PlaysetAccessories.linkAccessory(playsetId, accessoryId, quantity);
+    res.status(201).json(link);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+// List all links
+router.get('/playset-accessories', async (req, res) => {
+  try {
+    const links = await PlaysetAccessories.findAll();
+    res.json(links);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+// Update quantity for a link
+router.put('/playset-accessories/:id', async (req, res) => {
+  try {
+    const { quantity } = req.body;
+    const link = await PlaysetAccessories.findById(req.params.id);
+    if (!link) return res.status(404).json({ message: 'Vinculo no encontrado' });
+    await PlaysetAccessories.updateLink(req.params.id, quantity);
+    res.json({ message: 'Vinculo actualizado' });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+// Delete link
+router.delete('/playset-accessories/:id', async (req, res) => {
+  try {
+    const link = await PlaysetAccessories.findById(req.params.id);
+    if (!link) return res.status(404).json({ message: 'Vinculo no encontrado' });
+    await PlaysetAccessories.deleteLink(req.params.id);
+    res.json({ message: 'Vinculo eliminado' });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+module.exports = router;

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -2,6 +2,7 @@ const { expect } = require('chai');
 const materialsRouter = require('../routes/materials');
 const accessoriesRouter = require('../routes/accessories');
 const playsetsRouter = require('../routes/playsets');
+const playsetAccessoriesRouter = require('../routes/playsetAccessories');
 const materialAttributesRouter = require('../routes/materialAttributes');
 const accessoryMaterialsRouter = require('../routes/accessoryMaterials');
 
@@ -24,5 +25,9 @@ describe('Route definitions', () => {
 
   it('accessory materials router has routes configured', () => {
     expect(accessoryMaterialsRouter.stack).to.be.an('array').that.is.not.empty;
+  });
+
+  it('playset accessories router has routes configured', () => {
+    expect(playsetAccessoriesRouter.stack).to.be.an('array').that.is.not.empty;
   });
 });


### PR DESCRIPTION
## Summary
- implement `/playset-accessories` router with CRUD handlers
- mount the router in `api.js`
- test that the new router exposes routes
- document new endpoints in README
- extend Postman collections with playset accessories requests

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849efd067a8832db6ff916e087e8ef0