### PR TITLE
Add playset cost route

### DIFF
--- a/routes/playsets.js
+++ b/routes/playsets.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const Playsets = require('../models/playsetsModel');
+const PlaysetAccessories = require('../models/playsetAccessoriesModel');
 const router = express.Router();
 
 router.get('/playsets', async (req, res) => {
@@ -16,6 +17,16 @@ router.get('/playsets/:id', async (req, res) => {
     const playset = await Playsets.findById(req.params.id);
     if (!playset) return res.status(404).json({ message: 'Playset no encontrado' });
     res.json(playset);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.get('/playsets/:id/cost', async (req, res) => {
+  try {
+    const result = await PlaysetAccessories.calculatePlaysetCost(req.params.id);
+    if (!result) return res.status(404).json({ message: 'Playset no encontrado' });
+    res.json(result);
   } catch (error) {
     res.status(500).json({ message: error.message });
   }

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -2,7 +2,6 @@ const { expect } = require('chai');
 const materialsRouter = require('../routes/materials');
 const accessoriesRouter = require('../routes/accessories');
 const playsetsRouter = require('../routes/playsets');
-const playsetAccessoriesRouter = require('../routes/playsetAccessories');
 const materialAttributesRouter = require('../routes/materialAttributes');
 const accessoryMaterialsRouter = require('../routes/accessoryMaterials');
 const playsetAccessoriesRouter = require('../routes/playsetAccessories');
@@ -18,6 +17,13 @@ describe('Route definitions', () => {
 
   it('playsets router has routes configured', () => {
     expect(playsetsRouter.stack).to.be.an('array').that.is.not.empty;
+  });
+
+  it('playsets router registers cost route', () => {
+    const hasRoute = playsetsRouter.stack.some(
+      layer => layer.route && layer.route.path === '/playsets/:id/cost' && layer.route.methods.get
+    );
+    expect(hasRoute).to.be.true;
   });
 
   it('material attributes router has routes configured', () => {


### PR DESCRIPTION
## Summary
- expose PlaysetAccessories on playsets router
- add GET `/playsets/:id/cost` route
- verify the new cost route in unit tests

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f4658910832d91f6abc90a9bd092