### PR TITLE
Implement accessory costs on playset listing

### DIFF
--- a/models/playsetAccessoriesModel.js
+++ b/models/playsetAccessoriesModel.js
@@ -39,7 +39,10 @@ const findAll = () => {
 };
 
 const calculatePlaysetCost = async (playsetId) => {
-  const playsetRows = await query('SELECT id, name FROM playsets WHERE id = ?', [playsetId]);
+  const playsetRows = await query(
+    'SELECT id, name, description FROM playsets WHERE id = ?',
+    [playsetId]
+  );
   if (playsetRows.length === 0) return null;
   const accessoryRows = await query(
     `SELECT pa.accessory_id, pa.quantity, a.name
@@ -78,6 +81,7 @@ const calculatePlaysetCost = async (playsetId) => {
   return {
     playset_id: playsetRows[0].id,
     playset_name: playsetRows[0].name,
+    playset_description: playsetRows[0].description,
     total_cost,
     accessories
   };

--- a/routes/playsets.js
+++ b/routes/playsets.js
@@ -6,7 +6,19 @@ const router = express.Router();
 router.get('/playsets', async (req, res) => {
   try {
     const playsets = await Playsets.findAll();
-    res.json(playsets);
+    const detailed = await Promise.all(
+      playsets.map(async (p) => {
+        const costInfo = await PlaysetAccessories.calculatePlaysetCost(p.id);
+        return {
+          id: p.id,
+          name: p.name,
+          description: p.description,
+          accessories: costInfo ? costInfo.accessories : [],
+          total_cost: costInfo ? costInfo.total_cost : 0
+        };
+      })
+    );
+    res.json(detailed);
   } catch (error) {
     res.status(500).json({ message: error.message });
   }


### PR DESCRIPTION
## Summary
- include playset description when calculating costs
- list accessories and total cost in `GET /playsets`

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f75dc75c832d8eb994c7c3538ecd