### PR TITLE
docs: add test setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,13 @@ especifica se permite cualquier origen.
 
 ## Pruebas
 
-Ejecuta `npm test` para correr las pruebas unitarias con Mocha.
+Para asegurarte de que las dependencias de desarrollo necesarias para las
+pruebas estén instaladas, ejecuta primero `npm install` y luego `npm test`:
+
+```bash
+npm install
+npm test
+```
+
+También puedes usar el script `run-tests.sh` incluido en este repositorio, el
+cual instala las dependencias y lanza las pruebas en un solo paso.

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+npm install
+npm test


### PR DESCRIPTION
## Summary
- document installing dev dependencies before running tests
- add helper script `run-tests.sh`

## Testing
- `npm install`
- `npm test`
- `./run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849fa8c3c4c832db56eaba099937cc0