### PR TITLE
Add Swagger docs

### DIFF
--- a/api.js
+++ b/api.js
@@ -6,6 +6,8 @@ const cookieParser = require('cookie-parser');
 require('dotenv').config();
 require('./middlewares/passport');
 const cors = require('cors');
+const swaggerUi = require('swagger-ui-express');
+const swaggerSpec = require('./swagger');
 
 const userRouter = require('./routes/users');
 const authRouter = require('./routes/auth');
@@ -31,6 +33,9 @@ const port = process.env.PORT || 3000;
 app.use(cookieParser());
 
 app.use(bodyParser.json());
+
+// Documentación Swagger
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 
 // Rutas de autentcacion

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
     "mysql": "^2.18.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
-    "passport-local": "^1.0.0"
+    "passport-local": "^1.0.0",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^4.7.2"
   },
   "devDependencies": {
     "nodemon": "^3.0.3",

--- a/routes/accessories.js
+++ b/routes/accessories.js
@@ -2,6 +2,81 @@ const express = require('express');
 const Accessories = require('../models/accessoriesModel');
 const router = express.Router();
 
+/**
+ * @openapi
+ * /accessories:
+ *   get:
+ *     summary: Listar accesorios
+ *     tags:
+ *       - Accessories
+ *     responses:
+ *       200:
+ *         description: Lista de accesorios
+ *   post:
+ *     summary: Crear accesorio
+ *     tags:
+ *       - Accessories
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Accesorio creado
+ *
+ * /accessories/{id}:
+ *   get:
+ *     summary: Obtener accesorio por ID
+ *     tags:
+ *       - Accessories
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Accesorio encontrado
+ *       404:
+ *         description: Accesorio no encontrado
+ *   put:
+ *     summary: Actualizar accesorio
+ *     tags:
+ *       - Accessories
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Accesorio actualizado
+ *       404:
+ *         description: Accesorio no encontrado
+ *   delete:
+ *     summary: Eliminar accesorio
+ *     tags:
+ *       - Accessories
+ *     responses:
+ *       200:
+ *         description: Accesorio eliminado
+ *       404:
+ *         description: Accesorio no encontrado
+ */
+
 router.get('/accessories', async (req, res) => {
   try {
     const accessories = await Accessories.findAll();

--- a/routes/accessoryMaterials.js
+++ b/routes/accessoryMaterials.js
@@ -2,6 +2,58 @@ const express = require('express');
 const AccessoryMaterials = require('../models/accessoryMaterialsModel');
 const router = express.Router();
 
+/**
+ * @openapi
+ * /accessory-materials:
+ *   get:
+ *     summary: Listar enlaces accesorio-material
+ *     tags:
+ *       - AccessoryMaterials
+ *     responses:
+ *       200:
+ *         description: Lista de enlaces
+ *   post:
+ *     summary: Vincular material a accesorio
+ *     tags:
+ *       - AccessoryMaterials
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               accessoryId:
+ *                 type: integer
+ *               materialId:
+ *                 type: integer
+ *               quantity:
+ *                 type: number
+ *               width:
+ *                 type: number
+ *               length:
+ *                 type: number
+ *     responses:
+ *       201:
+ *         description: Vinculo creado
+ *
+ * /accessories/{id}/materials-cost:
+ *   get:
+ *     summary: Obtener costo de materiales de un accesorio
+ *     tags:
+ *       - AccessoryMaterials
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Costos calculados
+ *       404:
+ *         description: Accesorio no encontrado
+ */
+
 router.post('/accessory-materials', async (req, res) => {
   try {
     const { accessoryId, materialId, quantity, width, length } = req.body;

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -7,6 +7,60 @@ const router = express.Router();
 require('dotenv').config();
 const jwtSecret = process.env.JWT_SECRET;
 
+/**
+ * @openapi
+ * /auth/register:
+ *   post:
+ *     summary: Registrar un nuevo usuario
+ *     tags:
+ *       - Auth
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               username:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Usuario creado
+ *
+ * /auth/login:
+ *   post:
+ *     summary: Iniciar sesión
+ *     tags:
+ *       - Auth
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               username:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Autenticación exitosa
+ *       401:
+ *         description: Credenciales inválidas
+ *
+ * /auth/logout:
+ *   post:
+ *     summary: Cerrar sesión
+ *     tags:
+ *       - Auth
+ *     responses:
+ *       200:
+ *         description: Logout exitoso
+ */
+
 // Ruta de registro de usuarios
 router.post('/register', async (req, res, next) => {
     try {

--- a/routes/files.js
+++ b/routes/files.js
@@ -5,6 +5,37 @@ const path = require('path');
 const fs = require('fs');
 const { readJSONFile } = require('../Modules/filesInformation');
 
+/**
+ * @openapi
+ * /files/upload:
+ *   post:
+ *     summary: Subir archivo de imagen
+ *     tags:
+ *       - Files
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               file:
+ *                 type: string
+ *                 format: binary
+ *     responses:
+ *       201:
+ *         description: Archivo subido
+ *
+ * /files/read-json:
+ *   get:
+ *     summary: Leer archivo JSON de la carpeta uploads
+ *     tags:
+ *       - Files
+ *     responses:
+ *       200:
+ *         description: Contenido del archivo JSON
+ */
+
 // Ruta de la carpeta donde se guardaran los archivos
 const uploadDirectory = './uploads';
 

--- a/routes/getApis.js
+++ b/routes/getApis.js
@@ -2,6 +2,18 @@ const express = require('express');
 const router = express.Router();
 const getApis = require('../Modules/apisInformation');
 
+/**
+ * @openapi
+ * /public-apis/get-api:
+ *   get:
+ *     summary: Obtener información de una API pública
+ *     tags:
+ *       - PublicAPIs
+ *     responses:
+ *       200:
+ *         description: Respuesta de la API pública
+ */
+
 // Ruta para obtener la informacion que se obtiene de la api publica
 router.get('/get-api', async (req, res) => {
     try {

--- a/routes/materialAttributes.js
+++ b/routes/materialAttributes.js
@@ -2,6 +2,38 @@ const express = require('express');
 const MaterialAttributes = require('../models/materialAttributesModel');
 const router = express.Router();
 
+/**
+ * @openapi
+ * /material-attributes:
+ *   get:
+ *     summary: Listar atributos de materiales
+ *     tags:
+ *       - MaterialAttributes
+ *     responses:
+ *       200:
+ *         description: Lista de atributos
+ *   post:
+ *     summary: Crear atributo
+ *     tags:
+ *       - MaterialAttributes
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               materialId:
+ *                 type: integer
+ *               attributeName:
+ *                 type: string
+ *               attributeValue:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Atributo creado
+ */
+
 router.post('/material-attributes', async (req, res) => {
   try {
     const { materialId, attributeName, attributeValue } = req.body;

--- a/routes/materials.js
+++ b/routes/materials.js
@@ -2,6 +2,97 @@ const express = require('express');
 const Materials = require('../models/materialsModel');
 const router = express.Router();
 
+/**
+ * @openapi
+ * /materials:
+ *   get:
+ *     summary: Listar materiales
+ *     tags:
+ *       - Materials
+ *     responses:
+ *       200:
+ *         description: Lista de materiales
+ *   post:
+ *     summary: Crear material
+ *     tags:
+ *       - Materials
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *               thickness_mm:
+ *                 type: number
+ *               width_m:
+ *                 type: number
+ *               length_m:
+ *                 type: number
+ *               price:
+ *                 type: number
+ *     responses:
+ *       201:
+ *         description: Material creado
+ *
+ * /materials/{id}:
+ *   get:
+ *     summary: Obtener material por ID
+ *     tags:
+ *       - Materials
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Material encontrado
+ *       404:
+ *         description: Material no encontrado
+ *   put:
+ *     summary: Actualizar material
+ *     tags:
+ *       - Materials
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *               thickness_mm:
+ *                 type: number
+ *               width_m:
+ *                 type: number
+ *               length_m:
+ *                 type: number
+ *               price:
+ *                 type: number
+ *     responses:
+ *       200:
+ *         description: Material actualizado
+ *       404:
+ *         description: Material no encontrado
+ *   delete:
+ *     summary: Eliminar material
+ *     tags:
+ *       - Materials
+ *     responses:
+ *       200:
+ *         description: Material eliminado
+ *       404:
+ *         description: Material no encontrado
+ */
+
 router.get('/materials', async (req, res) => {
   try {
     const materials = await Materials.findAll();

--- a/routes/operaciones.js
+++ b/routes/operaciones.js
@@ -4,6 +4,49 @@ const operaciones = require('../Modules/operacionesModule');
 const jwt = require('jsonwebtoken');
 const db = require('../db');
 
+/**
+ * @openapi
+ * /operaciones/suma-numeros:
+ *   post:
+ *     summary: Sumar dos números y guardar en base de datos
+ *     tags:
+ *       - Operaciones
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               numA:
+ *                 type: number
+ *               numB:
+ *                 type: number
+ *     responses:
+ *       200:
+ *         description: Resultado de la suma
+ *
+ * /operaciones/validacion-token-jwt:
+ *   post:
+ *     summary: Validar tokens JWT
+ *     tags:
+ *       - Operaciones
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               sessionToken:
+ *                 type: string
+ *               refreshToken:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Resultado de la validación
+ */
+
 // Ruta para obtener la informacion que se obtiene de la api publica
 router.post('/suma-numeros', async (req, res) => {
     const { numA, numB } = req.body;

--- a/routes/playsetAccessories.js
+++ b/routes/playsetAccessories.js
@@ -2,6 +2,67 @@ const express = require('express');
 const PlaysetAccessories = require('../models/playsetAccessoriesModel');
 const router = express.Router();
 
+/**
+ * @openapi
+ * /playset-accessories:
+ *   get:
+ *     summary: Listar enlaces playset-accesorio
+ *     tags:
+ *       - PlaysetAccessories
+ *     responses:
+ *       200:
+ *         description: Lista de enlaces
+ *   post:
+ *     summary: Crear enlace
+ *     tags:
+ *       - PlaysetAccessories
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               playsetId:
+ *                 type: integer
+ *               accessoryId:
+ *                 type: integer
+ *               quantity:
+ *                 type: integer
+ *     responses:
+ *       201:
+ *         description: Enlace creado
+ *
+ * /playset-accessories/{id}:
+ *   put:
+ *     summary: Actualizar enlace
+ *     tags:
+ *       - PlaysetAccessories
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               quantity:
+ *                 type: integer
+ *     responses:
+ *       200:
+ *         description: Enlace actualizado
+ *       404:
+ *         description: Vinculo no encontrado
+ *   delete:
+ *     summary: Eliminar enlace
+ *     tags:
+ *       - PlaysetAccessories
+ *     responses:
+ *       200:
+ *         description: Enlace eliminado
+ *       404:
+ *         description: Vinculo no encontrado
+ */
+
 // Create link between playset and accessory
 router.post('/playset-accessories', async (req, res) => {
   try {

--- a/routes/playsets.js
+++ b/routes/playsets.js
@@ -3,6 +3,97 @@ const Playsets = require('../models/playsetsModel');
 const PlaysetAccessories = require('../models/playsetAccessoriesModel');
 const router = express.Router();
 
+/**
+ * @openapi
+ * /playsets:
+ *   get:
+ *     summary: Listar playsets con costo calculado
+ *     tags:
+ *       - Playsets
+ *     responses:
+ *       200:
+ *         description: Lista de playsets
+ *   post:
+ *     summary: Crear playset
+ *     tags:
+ *       - Playsets
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Playset creado
+ *
+ * /playsets/{id}:
+ *   get:
+ *     summary: Obtener playset por ID
+ *     tags:
+ *       - Playsets
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Playset encontrado
+ *       404:
+ *         description: Playset no encontrado
+ *   put:
+ *     summary: Actualizar playset
+ *     tags:
+ *       - Playsets
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Playset actualizado
+ *       404:
+ *         description: Playset no encontrado
+ *   delete:
+ *     summary: Eliminar playset
+ *     tags:
+ *       - Playsets
+ *     responses:
+ *       200:
+ *         description: Playset eliminado
+ *       404:
+ *         description: Playset no encontrado
+ *
+ * /playsets/{id}/cost:
+ *   get:
+ *     summary: Calcular costo total de un playset
+ *     tags:
+ *       - Playsets
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Costo del playset
+ *       404:
+ *         description: Playset no encontrado
+ */
+
 router.get('/playsets', async (req, res) => {
   try {
     const playsets = await Playsets.findAll();

--- a/routes/users.js
+++ b/routes/users.js
@@ -3,6 +3,79 @@ const User = require('../models/usersModel');
 const bcrypt = require('bcryptjs');
 const router = express.Router();
 
+/**
+ * @openapi
+ * /users:
+ *   get:
+ *     summary: Obtener todos los usuarios
+ *     tags:
+ *       - Users
+ *     responses:
+ *       200:
+ *         description: Lista de usuarios
+ *   post:
+ *     summary: Crear un usuario
+ *     tags:
+ *       - Users
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               username:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Usuario creado
+ *
+ * /users/{id}:
+ *   get:
+ *     summary: Obtener un usuario por ID
+ *     tags:
+ *       - Users
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Usuario encontrado
+ *       404:
+ *         description: Usuario no existe
+ *   put:
+ *     summary: Actualizar un usuario
+ *     tags:
+ *       - Users
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               username:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Usuario actualizado
+ *       404:
+ *         description: Usuario no existe
+ *   delete:
+ *     summary: Eliminar un usuario
+ *     tags:
+ *       - Users
+ *     responses:
+ *       200:
+ *         description: Usuario eliminado
+ *       404:
+ *         description: Usuario no existe
+ */
+
 // Ruta para obtener todos los usuarios
 router.get('/users', async (req, res) => {
     try {

--- a/swagger.js
+++ b/swagger.js
@@ -1,0 +1,19 @@
+const swaggerJsdoc = require('swagger-jsdoc');
+
+const options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'API Node',
+      version: '1.0.0'
+    },
+    servers: [
+      {
+        url: `http://localhost:${process.env.PORT || 3000}`
+      }
+    ]
+  },
+  apis: ['./routes/*.js']
+};
+
+module.exports = swaggerJsdoc(options);


### PR DESCRIPTION
## Summary
- install swagger-jsdoc and swagger-ui-express
- expose `/api-docs` endpoint
- configure basic Swagger spec
- document routes with OpenAPI comments

## Testing
- `npm test` *(fails: mocha not found)*
- `node api.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6849fa844914832db5a91397427c566c