### PR TITLE
Fix token validation error message

### DIFF
--- a/routes/operaciones.js
+++ b/routes/operaciones.js
@@ -40,7 +40,7 @@ router.post('/suma-numeros', async (req, res) => {
 router.post('/validacion-token-jwt', async (req, res) => {
     const { sessionToken, refreshToken } = req.body;
     if (!sessionToken || !refreshToken) {
-        return res.status(400).json({ error: 'Se requieren dos números' });
+        return res.status(400).json({ error: 'Se requieren dos tokens' });
     }
     const resultST = await operaciones.validaToken(sessionToken);
     const resultRT = await operaciones.validaToken(refreshToken);


### PR DESCRIPTION
## Summary
- correct Spanish message when tokens are missing

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849fa75e988832d8ac535e3d95b36a1