### PR TITLE
Update swagger-ui-express dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",
     "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^4.7.2"
+    "swagger-ui-express": "^4.7.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.3",


### PR DESCRIPTION
## Summary
- update `swagger-ui-express` dependency version in `package.json`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: mocha not found)*
- `./run-tests.sh` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849fe80f8a0832d9bb3d83832034b16