### PR TITLE
Fix swagger-ui version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "mysql": "^2.18.1",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
-        "passport-local": "^1.0.0"
+        "passport-local": "^1.0.0",
+        "swagger-ui-express": "^4.7.0"
       },
       "devDependencies": {
         "nodemon": "^3.0.3"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",
     "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^4.7.1"
+    "swagger-ui-express": "^4.7.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.3",


### PR DESCRIPTION
## Summary
- set `swagger-ui-express` to a valid version
- update the lock file entry

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849ffc5b550832db8cca27ab3366d89