### PR TITLE
Fix README file reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ subida de archivos y consumo de APIs públicas.
 
 API_NODE_New.postman_collection.json es la colección actualizada para usar la API, incluyendo materiales, accesorios y playsets. Para el escenario de ejemplo se agregó el archivo `API_NODE_Scenario.postman_collection.json` que muestra cómo registrar materiales y vincularlos a un accesorio.
 
-y el examen teorico es el archivo word cuestionarioNode.dox
+y el examen teorico es el archivo word cuestinarioNode.docx
 
 ## Variables de entorno
 


### PR DESCRIPTION
## Summary
- fix README to reference the correct questionnaire file name

## Testing
- `bash run-tests.sh` *(fails: 403 Forbidden fetching npm packages)*

------
https://chatgpt.com/codex/tasks/task_e_684a01304b78832dadebaa42f0138a23