### PR TITLE
Add Swagger docs path info

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,13 @@ npm test
 
 También puedes usar el script `run-tests.sh` incluido en este repositorio, el
 cual instala las dependencias y lanza las pruebas en un solo paso.
+
+## Documentación Swagger
+
+La versión utilizada del paquete `swagger-ui-express` es ^5.0.1. Puedes acceder a la documentación interactiva en:
+
+```
+http://localhost:3000/api-docs
+```
+
+Cambia el puerto si usas un valor distinto en la variable `PORT`.


### PR DESCRIPTION
## Summary
- document how to access the Swagger UI

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a01a98898832db17cfc54a621c75f