### PR TITLE
Add project and client modules

### DIFF
--- a/API_NODE.postman_collection.json
+++ b/API_NODE.postman_collection.json
@@ -1,400 +1,531 @@
 {
-	"info": {
-		"_postman_id": "cfcbdda6-3acc-49d0-b4ad-878fa81b880c",
-		"name": "API_NODE",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "5427101",
-		"_collection_link": "https://restless-resonance-7003.postman.co/workspace/Team-Workspace~447810eb-9b25-4b91-8072-950e0f36f64a/collection/5427101-cfcbdda6-3acc-49d0-b4ad-878fa81b880c?action=share&source=collection_link&creator=5427101"
-	},
-	"item": [
-		{
-			"name": "Create User Protegida",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Authorization",
-						"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NWJlYWYwMzUyZGY4NDE2ZWMyNzUwN2QiLCJpYXQiOjE3MDcwMDM2MzJ9.05IGKO6Oi8216jmvN2UnB6-uaBxH0Q5hA7AKMzM6OME",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"nombre\": \"Daniel\",\r\n    \"correo\": \"minoru.salazar@gmail.com\",\r\n    \"edad\": \"20\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:3000/users",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "3000",
-					"path": [
-						"users"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Registro User",
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"username\": \"danielsal\",\r\n    \"password\": \"123456\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:3000/auth/register",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "3000",
-					"path": [
-						"auth",
-						"register"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Login User",
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"username\": \"minorusal\",\r\n    \"password\": \"123456\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:3000/auth/login",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "3000",
-					"path": [
-						"auth",
-						"login"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Logout User",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "",
-						"value": "",
-						"type": "text",
-						"disabled": true
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:3000/auth/logout",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "3000",
-					"path": [
-						"auth",
-						"logout"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get Users Protegida",
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Authorization",
-						"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NWJlYWYwMzUyZGY4NDE2ZWMyNzUwN2QiLCJpYXQiOjE3MDcwMDM2MzJ9.05IGKO6Oi8216jmvN2UnB6-uaBxH0Q5hA7AKMzM6OME",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:3000/users",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "3000",
-					"path": [
-						"users"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get Users Id Protegida",
-			"protocolProfileBehavior": {
-				"disableBodyPruning": true
-			},
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Authorization",
-						"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NWJlYWYwMzUyZGY4NDE2ZWMyNzUwN2QiLCJpYXQiOjE3MDcwMDM2MzJ9.05IGKO6Oi8216jmvN2UnB6-uaBxH0Q5hA7AKMzM6OME",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"nombre\": \"Daniel\",\r\n    \"correo\": \"minoru.salazar@gmail.com\",\r\n    \"edad\": \"20\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:3000/users/65becf28d1299a35702ee336",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "3000",
-					"path": [
-						"users",
-						"65becf28d1299a35702ee336"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Edit Users Id Protegida",
-			"request": {
-				"method": "PUT",
-				"header": [
-					{
-						"key": "Authorization",
-						"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NWJlYWYwMzUyZGY4NDE2ZWMyNzUwN2QiLCJpYXQiOjE3MDcwMDM2MzJ9.05IGKO6Oi8216jmvN2UnB6-uaBxH0Q5hA7AKMzM6OME",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"nombre\": \"Daniel Salazar\",\r\n    \"correo\": \"minoru.salazar@yahoo.com\",\r\n    \"edad\": \"28\"\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:3000/users/65becf28d1299a35702ee336",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "3000",
-					"path": [
-						"users",
-						"65becf28d1299a35702ee336"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "DeleteUsers Id Protegida",
-			"request": {
-				"method": "DELETE",
-				"header": [
-					{
-						"key": "Authorization",
-						"value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NWJlYWYwMzUyZGY4NDE2ZWMyNzUwN2QiLCJpYXQiOjE3MDcwMDM2MzJ9.05IGKO6Oi8216jmvN2UnB6-uaBxH0Q5hA7AKMzM6OME",
-						"type": "text"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:3000/users/65becf28d1299a35702ee336",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "3000",
-					"path": [
-						"users",
-						"65becf28d1299a35702ee336"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Upload File",
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "formdata",
-					"formdata": [
-						{
-							"key": "file",
-							"type": "file",
-							"src": "/C:/Users/minor/Downloads/material-dashboard-angular2-master/src/assets/img/tim_80x80.png"
-						}
-					]
-				},
-				"url": {
-					"raw": "http://localhost:3000/files/upload",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "3000",
-					"path": [
-						"files",
-						"upload"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Rear JSON",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "http://localhost:3000/files/read-json",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "3000",
-					"path": [
-						"files",
-						"read-json"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Consume Api",
-			"request": {
-				"method": "GET",
-				"header": [],
-				"url": {
-					"raw": "http://localhost:3000/public-apis/get-api",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "3000",
-					"path": [
-						"public-apis",
-						"get-api"
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Operaciones - Suma",
-			"request": {
-				"method": "POST",
-				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": "{\r\n    \"numA\": 52,\r\n    \"numB\": 2\r\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:3000/operaciones/suma-numeros",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "3000",
-					"path": [
-						"operaciones",
-						"suma-numeros"
-					]
-				}
-			},
-			"response": []
-                },
-                {
-                        "name": "List Playset Accessories",
-                        "request": {
-                                "method": "GET",
-                                "header": [
-                                        {"key": "Authorization", "value": "Bearer {{token}}"}
-                                ],
-                                "url": {
-                                        "raw": "http://localhost:3000/playset-accessories",
-                                        "protocol": "http",
-                                        "host": ["localhost"],
-                                        "port": "3000",
-                                        "path": ["playset-accessories"]
-                                }
-                        },
-                        "response": []
+  "info": {
+    "_postman_id": "cfcbdda6-3acc-49d0-b4ad-878fa81b880c",
+    "name": "API_NODE",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "5427101",
+    "_collection_link": "https://restless-resonance-7003.postman.co/workspace/Team-Workspace~447810eb-9b25-4b91-8072-950e0f36f64a/collection/5427101-cfcbdda6-3acc-49d0-b4ad-878fa81b880c?action=share&source=collection_link&creator=5427101"
+  },
+  "item": [
+    {
+      "name": "Create User Protegida",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NWJlYWYwMzUyZGY4NDE2ZWMyNzUwN2QiLCJpYXQiOjE3MDcwMDM2MzJ9.05IGKO6Oi8216jmvN2UnB6-uaBxH0Q5hA7AKMzM6OME",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"nombre\": \"Daniel\",\r\n    \"correo\": \"minoru.salazar@gmail.com\",\r\n    \"edad\": \"20\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:3000/users",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "users"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Registro User",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"username\": \"danielsal\",\r\n    \"password\": \"123456\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:3000/auth/register",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "auth",
+            "register"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Login User",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"username\": \"minorusal\",\r\n    \"password\": \"123456\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:3000/auth/login",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "auth",
+            "login"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Logout User",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "",
+            "value": "",
+            "type": "text",
+            "disabled": true
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:3000/auth/logout",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "auth",
+            "logout"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Get Users Protegida",
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NWJlYWYwMzUyZGY4NDE2ZWMyNzUwN2QiLCJpYXQiOjE3MDcwMDM2MzJ9.05IGKO6Oi8216jmvN2UnB6-uaBxH0Q5hA7AKMzM6OME",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:3000/users",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "users"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Get Users Id Protegida",
+      "protocolProfileBehavior": {
+        "disableBodyPruning": true
+      },
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NWJlYWYwMzUyZGY4NDE2ZWMyNzUwN2QiLCJpYXQiOjE3MDcwMDM2MzJ9.05IGKO6Oi8216jmvN2UnB6-uaBxH0Q5hA7AKMzM6OME",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"nombre\": \"Daniel\",\r\n    \"correo\": \"minoru.salazar@gmail.com\",\r\n    \"edad\": \"20\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:3000/users/65becf28d1299a35702ee336",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "users",
+            "65becf28d1299a35702ee336"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Edit Users Id Protegida",
+      "request": {
+        "method": "PUT",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NWJlYWYwMzUyZGY4NDE2ZWMyNzUwN2QiLCJpYXQiOjE3MDcwMDM2MzJ9.05IGKO6Oi8216jmvN2UnB6-uaBxH0Q5hA7AKMzM6OME",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"nombre\": \"Daniel Salazar\",\r\n    \"correo\": \"minoru.salazar@yahoo.com\",\r\n    \"edad\": \"28\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:3000/users/65becf28d1299a35702ee336",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "users",
+            "65becf28d1299a35702ee336"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "DeleteUsers Id Protegida",
+      "request": {
+        "method": "DELETE",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI2NWJlYWYwMzUyZGY4NDE2ZWMyNzUwN2QiLCJpYXQiOjE3MDcwMDM2MzJ9.05IGKO6Oi8216jmvN2UnB6-uaBxH0Q5hA7AKMzM6OME",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:3000/users/65becf28d1299a35702ee336",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "users",
+            "65becf28d1299a35702ee336"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Upload File",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            {
+              "key": "file",
+              "type": "file",
+              "src": "/C:/Users/minor/Downloads/material-dashboard-angular2-master/src/assets/img/tim_80x80.png"
+            }
+          ]
+        },
+        "url": {
+          "raw": "http://localhost:3000/files/upload",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "files",
+            "upload"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Rear JSON",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/files/read-json",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "files",
+            "read-json"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Consume Api",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/public-apis/get-api",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "public-apis",
+            "get-api"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Operaciones - Suma",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n    \"numA\": 52,\r\n    \"numB\": 2\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:3000/operaciones/suma-numeros",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "operaciones",
+            "suma-numeros"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "List Playset Accessories",
+      "request": {
+        "method": "GET",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{token}}"
+          }
+        ],
+        "url": {
+          "raw": "http://localhost:3000/playset-accessories",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "playset-accessories"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Clients",
+      "item": [
+        {
+          "name": "List Clients",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/clients",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "clients"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Client",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"contact_name\": \"John\",\n  \"company_name\": \"Acme Inc\",\n  \"address\": \"Address\",\n  \"requires_invoice\": true,\n  \"billing_info\": \"RFC\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
                 }
-        ]
+              }
+            },
+            "url": {
+              "raw": "http://localhost:3000/clients",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "clients"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Projects",
+      "item": [
+        {
+          "name": "List Projects",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/projects",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "projects"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Project",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"playset_id\": 1,\n  \"profit_margin\": 0.2,\n  \"client\": {\n    \"id\": 1\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "http://localhost:3000/projects",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "projects"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    }
+  ]
 }

--- a/API_NODE_New.postman_collection.json
+++ b/API_NODE_New.postman_collection.json
@@ -716,6 +716,94 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "Clients",
+      "item": [
+        {
+          "name": "List Clients",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{token}}" }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/clients",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["clients"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Client",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{token}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"contact_name\": \"John\",\n  \"company_name\": \"Acme Inc\",\n  \"address\": \"Address\",\n  \"requires_invoice\": true,\n  \"billing_info\": \"RFC\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:3000/clients",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["clients"]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Projects",
+      "item": [
+        {
+          "name": "List Projects",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{token}}" }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/projects",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["projects"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Project",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{token}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"playset_id\": 1,\n  \"profit_margin\": 0.2,\n  \"client\": {\n    \"id\": 1\n  }\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:3000/projects",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["projects"]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ]
 }

--- a/API_NODE_Scenario.postman_collection.json
+++ b/API_NODE_Scenario.postman_collection.json
@@ -533,6 +533,130 @@
         }
       },
       "response": []
+    },
+    {
+      "name": "Clients",
+      "item": [
+        {
+          "name": "List Clients",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/clients",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "clients"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Client",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"contact_name\": \"John\",\n  \"company_name\": \"Acme Inc\",\n  \"address\": \"Address\",\n  \"requires_invoice\": true,\n  \"billing_info\": \"RFC\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "http://localhost:3000/clients",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "clients"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Projects",
+      "item": [
+        {
+          "name": "List Projects",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/projects",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "projects"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Project",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"playset_id\": 1,\n  \"profit_margin\": 0.2,\n  \"client\": {\n    \"id\": 1\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "http://localhost:3000/projects",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "projects"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ DB_NAME=demodb
 - `GET /playset-accessories` Lista vínculos playset-accesorio (protegido).
 - `PUT /playset-accessories/:id` Actualiza la cantidad del vínculo (protegido).
 - `DELETE /playset-accessories/:id` Elimina un vínculo (protegido).
+- `GET /clients` Lista clientes (protegido).
+- `POST /clients` Crea un cliente (protegido).
+- `GET /projects` Lista proyectos (protegido).
+- `POST /projects` Crea un proyecto con cliente y playset (protegido).
 
 ## Ejemplo de construcción de un playset
 

--- a/api.js
+++ b/api.js
@@ -20,6 +20,8 @@ const playsetsRouter = require('./routes/playsets');
 const playsetAccessoriesRouter = require('./routes/playsetAccessories');
 const materialAttributesRouter = require('./routes/materialAttributes');
 const accessoryMaterialsRouter = require('./routes/accessoryMaterials');
+const clientsRouter = require('./routes/clients');
+const projectsRouter = require('./routes/projects');
 
 const app = express();
 app.use(passport.initialize());
@@ -81,6 +83,8 @@ app.use('/', authenticateJWT, accessoriesRouter);
 app.use('/', authenticateJWT, playsetsRouter);
 app.use('/', authenticateJWT, playsetAccessoriesRouter);
 app.use('/', authenticateJWT, materialAttributesRouter);
+app.use('/', authenticateJWT, clientsRouter);
+app.use('/', authenticateJWT, projectsRouter);
 
 // Middleware para manejar errores
 app.use((err, req, res, next) => {

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -55,3 +55,21 @@ CREATE TABLE IF NOT EXISTS demo_table (
     numB DECIMAL(10,2) NOT NULL,
     resultado DECIMAL(10,2) NOT NULL
 );
+
+CREATE TABLE IF NOT EXISTS clients (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    contact_name VARCHAR(100) NOT NULL,
+    company_name VARCHAR(100),
+    address TEXT,
+    requires_invoice BOOLEAN DEFAULT FALSE,
+    billing_info TEXT
+);
+
+CREATE TABLE IF NOT EXISTS projects (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    client_id INT NOT NULL,
+    playset_id INT NOT NULL,
+    sale_price DECIMAL(10,2),
+    FOREIGN KEY (client_id) REFERENCES clients(id),
+    FOREIGN KEY (playset_id) REFERENCES playsets(id)
+);

--- a/models/clientsModel.js
+++ b/models/clientsModel.js
@@ -1,0 +1,63 @@
+const db = require('../db');
+
+const createClient = (contactName, companyName, address, requiresInvoice, billingInfo) => {
+  return new Promise((resolve, reject) => {
+    const sql = `INSERT INTO clients (contact_name, company_name, address, requires_invoice, billing_info) VALUES (?, ?, ?, ?, ?)`;
+    db.query(sql, [contactName, companyName, address, requiresInvoice, billingInfo], (err, result) => {
+      if (err) return reject(err);
+      resolve({
+        id: result.insertId,
+        contact_name: contactName,
+        company_name: companyName,
+        address,
+        requires_invoice: requiresInvoice,
+        billing_info: billingInfo
+      });
+    });
+  });
+};
+
+const findById = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM clients WHERE id = ?', [id], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows[0]);
+    });
+  });
+};
+
+const findAll = () => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM clients', (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+};
+
+const updateClient = (id, contactName, companyName, address, requiresInvoice, billingInfo) => {
+  return new Promise((resolve, reject) => {
+    const sql = `UPDATE clients SET contact_name = ?, company_name = ?, address = ?, requires_invoice = ?, billing_info = ? WHERE id = ?`;
+    db.query(sql, [contactName, companyName, address, requiresInvoice, billingInfo, id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+const deleteClient = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('DELETE FROM clients WHERE id = ?', [id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+module.exports = {
+  createClient,
+  findById,
+  findAll,
+  updateClient,
+  deleteClient
+};

--- a/models/projectsModel.js
+++ b/models/projectsModel.js
@@ -1,0 +1,56 @@
+const db = require('../db');
+
+const createProject = (clientId, playsetId, salePrice) => {
+  return new Promise((resolve, reject) => {
+    const sql = `INSERT INTO projects (client_id, playset_id, sale_price) VALUES (?, ?, ?)`;
+    db.query(sql, [clientId, playsetId, salePrice], (err, result) => {
+      if (err) return reject(err);
+      resolve({ id: result.insertId, client_id: clientId, playset_id: playsetId, sale_price: salePrice });
+    });
+  });
+};
+
+const findById = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM projects WHERE id = ?', [id], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows[0]);
+    });
+  });
+};
+
+const findAll = () => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM projects', (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+};
+
+const updateProject = (id, clientId, playsetId, salePrice) => {
+  return new Promise((resolve, reject) => {
+    const sql = `UPDATE projects SET client_id = ?, playset_id = ?, sale_price = ? WHERE id = ?`;
+    db.query(sql, [clientId, playsetId, salePrice, id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+const deleteProject = (id) => {
+  return new Promise((resolve, reject) => {
+    db.query('DELETE FROM projects WHERE id = ?', [id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+module.exports = {
+  createProject,
+  findById,
+  findAll,
+  updateProject,
+  deleteProject
+};

--- a/routes/clients.js
+++ b/routes/clients.js
@@ -1,0 +1,143 @@
+const express = require('express');
+const Clients = require('../models/clientsModel');
+const router = express.Router();
+
+/**
+ * @openapi
+ * /clients:
+ *   get:
+ *     summary: Listar clientes
+ *     tags:
+ *       - Clients
+ *     responses:
+ *       200:
+ *         description: Lista de clientes
+ *   post:
+ *     summary: Crear cliente
+ *     tags:
+ *       - Clients
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               contact_name:
+ *                 type: string
+ *               company_name:
+ *                 type: string
+ *               address:
+ *                 type: string
+ *               requires_invoice:
+ *                 type: boolean
+ *               billing_info:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Cliente creado
+ *
+ * /clients/{id}:
+ *   get:
+ *     summary: Obtener cliente por ID
+ *     tags:
+ *       - Clients
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Cliente encontrado
+ *       404:
+ *         description: Cliente no encontrado
+ *   put:
+ *     summary: Actualizar cliente
+ *     tags:
+ *       - Clients
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               contact_name:
+ *                 type: string
+ *               company_name:
+ *                 type: string
+ *               address:
+ *                 type: string
+ *               requires_invoice:
+ *                 type: boolean
+ *               billing_info:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Cliente actualizado
+ *       404:
+ *         description: Cliente no encontrado
+ *   delete:
+ *     summary: Eliminar cliente
+ *     tags:
+ *       - Clients
+ *     responses:
+ *       200:
+ *         description: Cliente eliminado
+ *       404:
+ *         description: Cliente no encontrado
+ */
+router.get('/clients', async (req, res) => {
+  try {
+    const clients = await Clients.findAll();
+    res.json(clients);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.get('/clients/:id', async (req, res) => {
+  try {
+    const client = await Clients.findById(req.params.id);
+    if (!client) return res.status(404).json({ message: 'Cliente no encontrado' });
+    res.json(client);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.post('/clients', async (req, res) => {
+  try {
+    const { contact_name, company_name, address, requires_invoice, billing_info } = req.body;
+    const client = await Clients.createClient(contact_name, company_name, address, requires_invoice, billing_info);
+    res.status(201).json(client);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.put('/clients/:id', async (req, res) => {
+  try {
+    const { contact_name, company_name, address, requires_invoice, billing_info } = req.body;
+    const client = await Clients.findById(req.params.id);
+    if (!client) return res.status(404).json({ message: 'Cliente no encontrado' });
+    await Clients.updateClient(req.params.id, contact_name, company_name, address, requires_invoice, billing_info);
+    res.json({ message: 'Cliente actualizado' });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.delete('/clients/:id', async (req, res) => {
+  try {
+    const client = await Clients.findById(req.params.id);
+    if (!client) return res.status(404).json({ message: 'Cliente no encontrado' });
+    await Clients.deleteClient(req.params.id);
+    res.json({ message: 'Cliente eliminado' });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+module.exports = router;

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -1,0 +1,84 @@
+const express = require('express');
+const Clients = require('../models/clientsModel');
+const Projects = require('../models/projectsModel');
+const PlaysetAccessories = require('../models/playsetAccessoriesModel');
+const router = express.Router();
+
+/**
+ * @openapi
+ * /projects:
+ *   get:
+ *     summary: Listar proyectos
+ *     tags:
+ *       - Projects
+ *     responses:
+ *       200:
+ *         description: Lista de proyectos
+ *   post:
+ *     summary: Crear proyecto
+ *     tags:
+ *       - Projects
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               playset_id:
+ *                 type: integer
+ *               profit_margin:
+ *                 type: number
+ *               client:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                   contact_name:
+ *                     type: string
+ *                   company_name:
+ *                     type: string
+ *                   address:
+ *                     type: string
+ *                   requires_invoice:
+ *                     type: boolean
+ *                   billing_info:
+ *                     type: string
+ *     responses:
+ *       201:
+ *         description: Proyecto creado
+ */
+router.get('/projects', async (req, res) => {
+  try {
+    const projects = await Projects.findAll();
+    res.json(projects);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.post('/projects', async (req, res) => {
+  try {
+    const { playset_id, profit_margin = 0, client } = req.body;
+    if (!client) return res.status(400).json({ message: 'Cliente requerido' });
+
+    let clientRecord;
+    if (client.id) {
+      clientRecord = await Clients.findById(client.id);
+      if (!clientRecord) return res.status(404).json({ message: 'Cliente no encontrado' });
+    } else {
+      const { contact_name, company_name, address, requires_invoice, billing_info } = client;
+      clientRecord = await Clients.createClient(contact_name, company_name, address, requires_invoice, billing_info);
+    }
+
+    const costInfo = await PlaysetAccessories.calculatePlaysetCost(playset_id);
+    if (!costInfo) return res.status(404).json({ message: 'Playset no encontrado' });
+    const salePrice = +(costInfo.total_cost * (1 + profit_margin)).toFixed(2);
+    const project = await Projects.createProject(clientRecord.id, playset_id, salePrice);
+    res.status(201).json({ ...project, cost: costInfo.total_cost });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+module.exports = router;

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -3,6 +3,8 @@ const materials = require('../models/materialsModel');
 const accessories = require('../models/accessoriesModel');
 const playsets = require('../models/playsetsModel');
 const playsetAccessories = require('../models/playsetAccessoriesModel');
+const clients = require('../models/clientsModel');
+const projects = require('../models/projectsModel');
 
 describe('Model exports', () => {
   it('materials model exposes CRUD functions', () => {
@@ -25,6 +27,18 @@ describe('Model exports', () => {
 
   it('playsetAccessories model exposes cost function', () => {
     expect(playsetAccessories.calculatePlaysetCost).to.be.a('function');
+  });
+
+  it('clients model exposes CRUD functions', () => {
+    expect(clients.createClient).to.be.a('function');
+    expect(clients.findById).to.be.a('function');
+    expect(clients.findAll).to.be.a('function');
+  });
+
+  it('projects model exposes CRUD functions', () => {
+    expect(projects.createProject).to.be.a('function');
+    expect(projects.findById).to.be.a('function');
+    expect(projects.findAll).to.be.a('function');
   });
 });
 

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -5,6 +5,8 @@ const playsetsRouter = require('../routes/playsets');
 const materialAttributesRouter = require('../routes/materialAttributes');
 const accessoryMaterialsRouter = require('../routes/accessoryMaterials');
 const playsetAccessoriesRouter = require('../routes/playsetAccessories');
+const clientsRouter = require('../routes/clients');
+const projectsRouter = require('../routes/projects');
 
 describe('Route definitions', () => {
   it('materials router has routes configured', () => {
@@ -36,5 +38,13 @@ describe('Route definitions', () => {
 
   it('playset accessories router has routes configured', () => {
     expect(playsetAccessoriesRouter.stack).to.be.an('array').that.is.not.empty;
+  });
+
+  it('clients router has routes configured', () => {
+    expect(clientsRouter.stack).to.be.an('array').that.is.not.empty;
+  });
+
+  it('projects router has routes configured', () => {
+    expect(projectsRouter.stack).to.be.an('array').that.is.not.empty;
   });
 });


### PR DESCRIPTION
## Summary
- create migrations for clients and projects tables
- add models for clients and projects
- expose client and project routes
- register new routes in API
- document endpoints in README
- test route and model exports
- update Postman collections with client and project requests

## Testing
- `./run-tests.sh` *(fails: npm install issue)*

------
https://chatgpt.com/codex/tasks/task_e_684a0636c290832d8bd2bf1788d97c81