### PR TITLE
Add accessory details to projects endpoint

### DIFF
--- a/models/playsetAccessoriesModel.js
+++ b/models/playsetAccessoriesModel.js
@@ -98,7 +98,8 @@ const calculatePlaysetCost = async (playsetId) => {
       accessory_id: row.accessory_id,
       accessory_name: row.name,
       quantity: row.quantity,
-      cost
+      cost,
+      materials: mats
     });
   }
 


### PR DESCRIPTION
## Summary
- include materials in playset accessory cost calculation
- return detailed accessory info in `GET /projects` including costs with profit margin

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a1589a424832da64ddfbd84556029