### PR TITLE
Add issue date and validity note to generated PDF

### DIFF
--- a/routes/projects.js
+++ b/routes/projects.js
@@ -225,7 +225,14 @@ router.get('/projects/:id/pdf', async (req, res) => {
     res.setHeader('Content-Disposition', `attachment; filename=project_${project.id}.pdf`);
     doc.pipe(res);
 
-    doc.fontSize(16).text('Nota de Remision', { align: 'center' });
+    const issueDate = new Date();
+    const formattedDate = issueDate.toISOString().slice(0, 10);
+
+    doc.fontSize(16).text('Nota de Remisión', { align: 'center', underline: true });
+    doc.moveDown(0.5);
+    doc.fontSize(10).text(`Fecha de emisión: ${formattedDate}`, { align: 'right' });
+    doc.moveDown();
+    doc.moveTo(50, doc.y).lineTo(550, doc.y).stroke();
     doc.moveDown();
     doc.fontSize(12).text(`ID: ${project.id}`);
     if (project.contact_email) {
@@ -271,6 +278,12 @@ router.get('/projects/:id/pdf', async (req, res) => {
     doc.moveDown();
     doc.text(`Costo de inversion total: ${total_investment_cost.toFixed(2)}`);
     doc.text(`Costo de venta total: ${total_cost_with_margin.toFixed(2)}`);
+    doc.moveDown();
+    doc.moveTo(50, doc.y).lineTo(550, doc.y).stroke();
+    doc.moveDown();
+    doc.fontSize(10).text('Nota: Estos precios solo están disponibles durante 30 días a partir de la fecha de emisión de esta remisión.', {
+      align: 'center'
+    });
     doc.end();
   } catch (error) {
     res.status(500).json({ message: error.message });


### PR DESCRIPTION
## Summary
- show emission date in PDF
- add note about price validity for 30 days

## Testing
- `npm test` *(fails: `mocha: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a28bccac4832db8dfcdc0d040b254