### PR TITLE
Update remission pdf style

### DIFF
--- a/templates/remission.html
+++ b/templates/remission.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Remisión {{folio}}</title>
+  <style>
+    /* Reset y tipografía básica */
+    *{box-sizing:border-box;margin:0;padding:0;font-family:'Arial',sans-serif;color:#000}
+    body{padding:24px;font-size:12px;line-height:1.3}
+    h1{font-size:18px;margin-bottom:6px}
+    h2{font-size:14px;margin-top:12px}
+    table{width:100%;border-collapse:collapse;margin-top:8px}
+    th,td{border:1px solid #888;padding:4px;text-align:left;font-size:11px}
+    th{background:#f0f0f0;font-weight:600}
+    .right{text-align:right}
+    .center{text-align:center}
+    .small{font-size:10px}
+    .section{margin-top:16px}
+    .row{display:flex;justify-content:space-between}
+    .col{flex:1}
+    .stamp{border:1px dashed #888;padding:6px;font-size:10px}
+    /* Separadores */
+    hr{border:none;border-top:1px solid #888;margin:12px 0}
+  </style>
+</head>
+<body>
+  <!-- ENCABEZADO PRINCIPAL -->
+  <div class="row">
+    <div class="col">
+      <h1>REMISIÓN / CFDI 4.0</h1>
+      <p class="small">Folio Interno: <strong>{{folio}}</strong></p>
+      <p class="small">Fecha de emisión: <strong>{{fechaEmision}}</strong></p>
+      <p class="small">Lugar de expedición: <strong>{{lugarExpedicion}}</strong></p>
+    </div>
+    <div class="col right">
+      <!-- Logo (opcional) -->
+      <img src="{{logoSrc}}" alt="Logo" style="max-height:60px" />
+    </div>
+  </div>
+
+  <hr>
+
+  <!-- EMISOR -->
+  <div class="section">
+    <h2>Datos del Emisor</h2>
+    <table>
+      <tr><th>Razón Social</th><td>{{emisor.razonSocial}}</td></tr>
+      <tr><th>RFC</th><td>{{emisor.rfc}}</td></tr>
+      <tr><th>Régimen Fiscal</th><td>{{emisor.regimen}}</td></tr>
+    </table>
+  </div>
+
+  <!-- RECEPTOR -->
+  <div class="section">
+    <h2>Datos del Receptor</h2>
+    <table>
+      <tr><th>Razón Social</th><td>{{receptor.razonSocial}}</td></tr>
+      <tr><th>RFC</th><td>{{receptor.rfc}}</td></tr>
+      <tr><th>Uso CFDI</th><td>{{receptor.usoCfdi}}</td></tr>
+      <tr><th>Domicilio Fiscal</th><td>{{receptor.cp}}</td></tr>
+      <tr><th>Régimen Fiscal</th><td>{{receptor.regimen}}</td></tr>
+    </table>
+  </div>
+
+  <!-- CONCEPTOS -->
+  <div class="section">
+    <h2>Conceptos</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Cantidad</th>
+          <th>ClaveProdServ</th>
+          <th>Descripción</th>
+          <th>Valor Unitario</th>
+          <th>Importe</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#conceptos}}
+        <tr>
+          <td class="center">{{cantidad}}</td>
+          <td>{{claveProdServ}}</td>
+          <td>{{descripcion}}</td>
+          <td class="right">{{valorUnitario}}</td>
+          <td class="right">{{importe}}</td>
+        </tr>
+        {{/conceptos}}
+      </tbody>
+    </table>
+  </div>
+
+  <!-- TOTALES -->
+  <div class="section right">
+    <table style="width:50%;float:right">
+      <tr><th>Subtotal</th><td class="right">{{totales.subtotal}}</td></tr>
+      <tr><th>IVA ({{totales.tasaIva}})</th><td class="right">{{totales.iva}}</td></tr>
+      <tr><th>Total</th><td class="right"><strong>{{totales.total}}</strong></td></tr>
+    </table>
+    <div style="clear:both"></div>
+    <p class="small">Total en letra: <em>{{totales.totalLetra}}</em></p>
+  </div>
+
+  <hr>
+
+  <!-- SELLOS Y CADENAS -->
+  <div class="section">
+    <h2>Comprobación Fiscal</h2>
+    <p class="small"><strong>UUID:</strong> {{uuid}}</p>
+    <p class="small"><strong>Folio fiscal:</strong> {{folioFiscal}}</p>
+    <p class="small"><strong>Sello digital del SAT:</strong></p>
+    <div class="stamp">{{selloSat}}</div>
+    <p class="small"><strong>Sello digital del emisor:</strong></p>
+    <div class="stamp">{{selloEmisor}}</div>
+    <p class="small"><strong>Cadena original del complemento de certificación:</strong></p>
+    <div class="stamp">{{cadenaOriginal}}</div>
+  </div>
+
+  <hr>
+  <p class="small center">Este documento es una representación impresa de un CFDI – Página 1 de 1</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a reference HTML template for remission layout
- enhance PDF generation in `projects` route to include header, issuer/receptor data and totals

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a304a0240832d8a15385538a8fa53