### PR TITLE
Add owner linking and profit tracking

### DIFF
--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -162,8 +162,50 @@ CREATE TABLE IF NOT EXISTS owner_companies (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
     address TEXT,
+    profit_percentage DECIMAL(10,2) DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
+
+/* ──────────── Asociaciones con owner ──────────── */
+ALTER TABLE raw_materials
+  ADD COLUMN owner_id INT,
+  ADD CONSTRAINT FOREIGN KEY (owner_id) REFERENCES owner_companies(id);
+
+ALTER TABLE material_attributes
+  ADD COLUMN owner_id INT,
+  ADD CONSTRAINT FOREIGN KEY (owner_id) REFERENCES owner_companies(id);
+
+ALTER TABLE accessories
+  ADD COLUMN owner_id INT,
+  ADD CONSTRAINT FOREIGN KEY (owner_id) REFERENCES owner_companies(id);
+
+ALTER TABLE accessory_materials
+  ADD COLUMN owner_id INT,
+  ADD CONSTRAINT FOREIGN KEY (owner_id) REFERENCES owner_companies(id);
+
+ALTER TABLE playsets
+  ADD COLUMN owner_id INT,
+  ADD CONSTRAINT FOREIGN KEY (owner_id) REFERENCES owner_companies(id);
+
+ALTER TABLE playset_accessories
+  ADD COLUMN owner_id INT,
+  ADD CONSTRAINT FOREIGN KEY (owner_id) REFERENCES owner_companies(id);
+
+ALTER TABLE demo_table
+  ADD COLUMN owner_id INT,
+  ADD CONSTRAINT FOREIGN KEY (owner_id) REFERENCES owner_companies(id);
+
+ALTER TABLE clients
+  ADD COLUMN owner_id INT,
+  ADD CONSTRAINT FOREIGN KEY (owner_id) REFERENCES owner_companies(id);
+
+ALTER TABLE projects
+  ADD COLUMN owner_id INT,
+  ADD CONSTRAINT FOREIGN KEY (owner_id) REFERENCES owner_companies(id);
+
+ALTER TABLE remissions
+  ADD COLUMN owner_id INT,
+  ADD CONSTRAINT FOREIGN KEY (owner_id) REFERENCES owner_companies(id);
 
 

--- a/models/accessoriesModel.js
+++ b/models/accessoriesModel.js
@@ -7,12 +7,12 @@ const db = require('../db');
  * @returns {Promise<object>} Accesorio creado con su ID.
  * @throws {Error} Si ocurre un error en la base de datos.
  */
-const createAccessory = (name, description) => {
+const createAccessory = (name, description, ownerId = 1) => {
   return new Promise((resolve, reject) => {
-    const sql = 'INSERT INTO accessories (name, description) VALUES (?, ?)';
-    db.query(sql, [name, description], (err, result) => {
+    const sql = 'INSERT INTO accessories (name, description, owner_id) VALUES (?, ?, ?)';
+    db.query(sql, [name, description, ownerId], (err, result) => {
       if (err) return reject(err);
-      resolve({ id: result.insertId, name, description });
+      resolve({ id: result.insertId, name, description, owner_id: ownerId });
     });
   });
 };

--- a/models/accessoryMaterialsModel.js
+++ b/models/accessoryMaterialsModel.js
@@ -10,16 +10,16 @@ const db = require('../db');
  * @returns {Promise<object>} Registro creado con su ID.
  * @throws {Error} Si ocurre un error en la inserción.
  */
-const linkMaterial = (accessoryId, materialId, quantity, width, length) => {
+const linkMaterial = (accessoryId, materialId, quantity, width, length, ownerId = 1) => {
   return new Promise((resolve, reject) => {
     const sql =
-      'INSERT INTO accessory_materials (accessory_id, material_id, quantity, width_m, length_m) VALUES (?, ?, ?, ?, ?)';
+      'INSERT INTO accessory_materials (accessory_id, material_id, quantity, width_m, length_m, owner_id) VALUES (?, ?, ?, ?, ?, ?)';
     db.query(
       sql,
-      [accessoryId, materialId, quantity, width, length],
+      [accessoryId, materialId, quantity, width, length, ownerId],
       (err, result) => {
         if (err) return reject(err);
-        resolve({ id: result.insertId, accessoryId, materialId, quantity, width, length });
+        resolve({ id: result.insertId, accessoryId, materialId, quantity, width, length, owner_id: ownerId });
       }
     );
   });

--- a/models/clientsModel.js
+++ b/models/clientsModel.js
@@ -1,9 +1,16 @@
 const db = require('../db');
 
-const createClient = (contactName, companyName, address, requiresInvoice, billingInfo) => {
+const createClient = (
+  contactName,
+  companyName,
+  address,
+  requiresInvoice,
+  billingInfo,
+  ownerId = 1
+) => {
   return new Promise((resolve, reject) => {
-    const sql = `INSERT INTO clients (contact_name, company_name, address, requires_invoice, billing_info) VALUES (?, ?, ?, ?, ?)`;
-    db.query(sql, [contactName, companyName, address, requiresInvoice, billingInfo], (err, result) => {
+    const sql = `INSERT INTO clients (contact_name, company_name, address, requires_invoice, billing_info, owner_id) VALUES (?, ?, ?, ?, ?, ?)`;
+    db.query(sql, [contactName, companyName, address, requiresInvoice, billingInfo, ownerId], (err, result) => {
       if (err) return reject(err);
       resolve({
         id: result.insertId,
@@ -11,7 +18,8 @@ const createClient = (contactName, companyName, address, requiresInvoice, billin
         company_name: companyName,
         address,
         requires_invoice: requiresInvoice,
-        billing_info: billingInfo
+        billing_info: billingInfo,
+        owner_id: ownerId
       });
     });
   });

--- a/models/materialAttributesModel.js
+++ b/models/materialAttributesModel.js
@@ -8,12 +8,12 @@ const db = require('../db');
  * @returns {Promise<object>} Atributo creado con su ID.
  * @throws {Error} Si ocurre un error al insertar el registro.
  */
-const createAttribute = (materialId, attributeName, attributeValue) => {
+const createAttribute = (materialId, attributeName, attributeValue, ownerId = 1) => {
   return new Promise((resolve, reject) => {
-    const sql = 'INSERT INTO material_attributes (material_id, attribute_name, attribute_value) VALUES (?, ?, ?)';
-    db.query(sql, [materialId, attributeName, attributeValue], (err, result) => {
+    const sql = 'INSERT INTO material_attributes (material_id, attribute_name, attribute_value, owner_id) VALUES (?, ?, ?, ?)';
+    db.query(sql, [materialId, attributeName, attributeValue, ownerId], (err, result) => {
       if (err) return reject(err);
-      resolve({ id: result.insertId, materialId, attributeName, attributeValue });
+      resolve({ id: result.insertId, materialId, attributeName, attributeValue, owner_id: ownerId });
     });
   });
 };

--- a/models/materialsModel.js
+++ b/models/materialsModel.js
@@ -11,13 +11,21 @@ const db = require('../db');
  * @returns {Promise<object>} Material creado con su ID.
  * @throws {Error} Si ocurre un error en la base de datos.
  */
-const createMaterial = (name, description, thickness, width, length, price) => {
+const createMaterial = (
+  name,
+  description,
+  thickness,
+  width,
+  length,
+  price,
+  ownerId = 1
+) => {
   return new Promise((resolve, reject) => {
     const sql =
-      'INSERT INTO raw_materials (name, description, thickness_mm, width_m, length_m, price) VALUES (?, ?, ?, ?, ?, ?)';
+      'INSERT INTO raw_materials (name, description, thickness_mm, width_m, length_m, price, owner_id) VALUES (?, ?, ?, ?, ?, ?, ?)';
     db.query(
       sql,
-      [name, description, thickness, width, length, price],
+      [name, description, thickness, width, length, price, ownerId],
       (err, result) => {
         if (err) return reject(err);
         resolve({
@@ -27,7 +35,8 @@ const createMaterial = (name, description, thickness, width, length, price) => {
           thickness_mm: thickness,
           width_m: width,
           length_m: length,
-          price
+          price,
+          owner_id: ownerId
         });
       }
     );

--- a/models/playsetAccessoriesModel.js
+++ b/models/playsetAccessoriesModel.js
@@ -18,12 +18,12 @@ const query = (sql, params = []) => {
  * @returns {Promise<object>} Registro creado con su ID.
  * @throws {Error} Si la inserción falla.
  */
-const linkAccessory = (playsetId, accessoryId, quantity) => {
+const linkAccessory = (playsetId, accessoryId, quantity, ownerId = 1) => {
   return new Promise((resolve, reject) => {
-    const sql = 'INSERT INTO playset_accessories (playset_id, accessory_id, quantity) VALUES (?, ?, ?)';
-    db.query(sql, [playsetId, accessoryId, quantity], (err, result) => {
+    const sql = 'INSERT INTO playset_accessories (playset_id, accessory_id, quantity, owner_id) VALUES (?, ?, ?, ?)';
+    db.query(sql, [playsetId, accessoryId, quantity, ownerId], (err, result) => {
       if (err) return reject(err);
-      resolve({ id: result.insertId, playsetId, accessoryId, quantity });
+      resolve({ id: result.insertId, playsetId, accessoryId, quantity, owner_id: ownerId });
     });
   });
 };

--- a/models/playsetsModel.js
+++ b/models/playsetsModel.js
@@ -7,12 +7,12 @@ const db = require('../db');
  * @returns {Promise<object>} Playset creado con su ID.
  * @throws {Error} Si la inserción falla.
  */
-const createPlayset = (name, description) => {
+const createPlayset = (name, description, ownerId = 1) => {
   return new Promise((resolve, reject) => {
-    const sql = 'INSERT INTO playsets (name, description) VALUES (?, ?)';
-    db.query(sql, [name, description], (err, result) => {
+    const sql = 'INSERT INTO playsets (name, description, owner_id) VALUES (?, ?, ?)';
+    db.query(sql, [name, description, ownerId], (err, result) => {
       if (err) return reject(err);
-      resolve({ id: result.insertId, name, description });
+      resolve({ id: result.insertId, name, description, owner_id: ownerId });
     });
   });
 };

--- a/models/projectsModel.js
+++ b/models/projectsModel.js
@@ -1,16 +1,23 @@
 const db = require('../db');
 
-const createProject = (clientId, playsetId, salePrice, contactEmail) => {
+const createProject = (
+  clientId,
+  playsetId,
+  salePrice,
+  contactEmail,
+  ownerId = 1
+) => {
   return new Promise((resolve, reject) => {
-    const sql = `INSERT INTO projects (client_id, playset_id, sale_price, contact_email) VALUES (?, ?, ?, ?)`;
-    db.query(sql, [clientId, playsetId, salePrice, contactEmail], (err, result) => {
+    const sql = `INSERT INTO projects (client_id, playset_id, sale_price, contact_email, owner_id) VALUES (?, ?, ?, ?, ?)`;
+    db.query(sql, [clientId, playsetId, salePrice, contactEmail, ownerId], (err, result) => {
       if (err) return reject(err);
       resolve({
         id: result.insertId,
         client_id: clientId,
         playset_id: playsetId,
         sale_price: salePrice,
-        contact_email: contactEmail
+        contact_email: contactEmail,
+        owner_id: ownerId
       });
     });
   });

--- a/models/remissionsModel.js
+++ b/models/remissionsModel.js
@@ -1,15 +1,16 @@
 const db = require('../db');
 
-const createRemission = (projectId, data, pdfPath) => {
+const createRemission = (projectId, data, pdfPath, ownerId = 1) => {
   return new Promise((resolve, reject) => {
-    const sql = `INSERT INTO remissions (project_id, data, pdf_path) VALUES (?, ?, ?)`;
-    db.query(sql, [projectId, data, pdfPath], (err, result) => {
+    const sql = `INSERT INTO remissions (project_id, data, pdf_path, owner_id) VALUES (?, ?, ?, ?)`;
+    db.query(sql, [projectId, data, pdfPath, ownerId], (err, result) => {
       if (err) return reject(err);
       resolve({
         id: result.insertId,
         project_id: projectId,
         data: JSON.parse(data),
-        pdf_path: pdfPath
+        pdf_path: pdfPath,
+        owner_id: ownerId
       });
     });
   });

--- a/routes/accessories.js
+++ b/routes/accessories.js
@@ -106,7 +106,7 @@ router.get('/accessories/:id', async (req, res) => {
 router.post('/accessories', async (req, res) => {
   try {
     const { name, description } = req.body;
-    const accessory = await Accessories.createAccessory(name, description);
+    const accessory = await Accessories.createAccessory(name, description, 1);
     res.status(201).json(accessory);
   } catch (error) {
     res.status(500).json({ message: error.message });

--- a/routes/accessoryMaterials.js
+++ b/routes/accessoryMaterials.js
@@ -61,7 +61,8 @@ router.post('/accessory-materials', async (req, res) => {
       materialId,
       quantity,
       width,
-      length
+      length,
+      1
     );
     const cost = await AccessoryMaterials.calculateCost(
       materialId,

--- a/routes/clients.js
+++ b/routes/clients.js
@@ -110,7 +110,7 @@ router.get('/clients/:id', async (req, res) => {
 router.post('/clients', async (req, res) => {
   try {
     const { contact_name, company_name, address, requires_invoice, billing_info } = req.body;
-    const client = await Clients.createClient(contact_name, company_name, address, requires_invoice, billing_info);
+    const client = await Clients.createClient(contact_name, company_name, address, requires_invoice, billing_info, 1);
     res.status(201).json(client);
   } catch (error) {
     res.status(500).json({ message: error.message });

--- a/routes/materials.js
+++ b/routes/materials.js
@@ -135,7 +135,8 @@ router.post('/materials', async (req, res) => {
       thickness_mm,
       width_m,
       length_m,
-      price
+      price,
+      1
     );
     res.status(201).json(material);
   } catch (error) {

--- a/routes/operaciones.js
+++ b/routes/operaciones.js
@@ -55,7 +55,7 @@ router.post('/suma-numeros', async (req, res) => {
     }
     const result = await operaciones.sumaDosNumeros(numA, numB);
 
-    const sqlInsert = 'INSERT INTO demo_table (numA, numB, resultado) VALUES (?, ?, ?)';
+    const sqlInsert = 'INSERT INTO demo_table (numA, numB, resultado, owner_id) VALUES (?, ?, ?, 1)';
     const queryValues = [numA, numB, result];
 
     // Ejecutar la consulta de inserción en la base de datos

--- a/routes/playsetAccessories.js
+++ b/routes/playsetAccessories.js
@@ -67,7 +67,7 @@ const router = express.Router();
 router.post('/playset-accessories', async (req, res) => {
   try {
     const { playsetId, accessoryId, quantity } = req.body;
-    const link = await PlaysetAccessories.linkAccessory(playsetId, accessoryId, quantity);
+    const link = await PlaysetAccessories.linkAccessory(playsetId, accessoryId, quantity, 1);
     res.status(201).json(link);
   } catch (error) {
     res.status(500).json({ message: error.message });

--- a/routes/playsets.js
+++ b/routes/playsets.js
@@ -149,7 +149,7 @@ router.get('/playsets/:id/cost', async (req, res) => {
 router.post('/playsets', async (req, res) => {
   try {
     const { name, description } = req.body;
-    const playset = await Playsets.createPlayset(name, description);
+    const playset = await Playsets.createPlayset(name, description, 1);
     res.status(201).json(playset);
   } catch (error) {
     res.status(500).json({ message: error.message });

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -96,6 +96,7 @@ router.get('/projects', async (req, res) => {
           playset_description: costInfo.playset_description,
           accessories,
           profit_margin,
+          profit_percentage: +(profit_margin * 100).toFixed(2),
           total_investment_cost,
           total_cost_with_margin
         };
@@ -170,6 +171,7 @@ router.get('/projects/:id', async (req, res) => {
       playset_description: costInfo.playset_description,
       accessories,
       profit_margin,
+      profit_percentage: +(profit_margin * 100).toFixed(2),
       total_investment_cost,
       total_cost_with_margin
     });
@@ -243,7 +245,7 @@ router.get('/projects/:id/pdf', async (req, res) => {
       total_cost_with_margin
     });
     try {
-      await Remissions.createRemission(project.id, snapshot, filePath);
+      await Remissions.createRemission(project.id, snapshot, filePath, 1);
     } catch (err) {
       console.error('Error saving remission:', err);
     }
@@ -259,7 +261,8 @@ router.get('/projects/:id/pdf', async (req, res) => {
       cantidad: acc.quantity,
       descripcion: acc.accessory_name,
       costoInversion: acc.investment_cost.toFixed(2),
-      costoVenta: acc.cost_with_margin.toFixed(2)
+      costoVenta: acc.cost_with_margin.toFixed(2),
+      porcentaje: (profit_margin * 100).toFixed(2) + '%'
     }));
 
 
@@ -325,7 +328,8 @@ router.post('/projects', async (req, res) => {
       clientRecord.id,
       playset_id,
       salePrice,
-      contact_email
+      contact_email,
+      1
     );
     res.status(201).json({ ...project, cost: costInfo.total_cost });
   } catch (error) {

--- a/templates/remission.html
+++ b/templates/remission.html
@@ -68,6 +68,7 @@
           <th>Descripción</th>
           <th>Costo de inversión</th>
           <th>Costo para venta</th>
+          <th>Porcentaje</th>
         </tr>
       </thead>
       <tbody>
@@ -77,6 +78,7 @@
           <td>{{descripcion}}</td>
           <td class="right">{{costoInversion}}</td>
           <td class="right">{{costoVenta}}</td>
+          <td class="right">{{porcentaje}}</td>
         </tr>
         {{/conceptos}}
       </tbody>

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -66,7 +66,8 @@ describe('Model logic', () => {
       5,
       2,
       3,
-      20
+      20,
+      1
     );
 
     expect(result).to.deep.equal({
@@ -76,7 +77,8 @@ describe('Model logic', () => {
       thickness_mm: 5,
       width_m: 2,
       length_m: 3,
-      price: 20
+      price: 20,
+      owner_id: 1
     });
   });
 


### PR DESCRIPTION
## Summary
- track profit percentage per owner company
- link all records to an owner
- show the profit percentage in project PDFs
- adjust DB access and tests for new owner columns

## Testing
- `./run-tests.sh` *(fails: npm install 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684a380ea9a8832d88407dcbbf875b51