### PR TITLE
Generate owner and client remissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,13 @@ http://localhost:3000/api-docs
 ```
 
 Cambia el puerto si usas un valor distinto en la variable `PORT`.
+
+## Actualización de remisiones
+
+Para identificar si una remisión es para el propietario de la empresa o para el cliente, se añadió la columna `recipient_type` a la tabla `remissions`.
+
+Si ya tienes datos y sólo quieres aplicar el cambio ejecuta:
+
+```sql
+ALTER TABLE remissions ADD COLUMN recipient_type ENUM('owner','client') DEFAULT 'owner';
+```

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -154,6 +154,7 @@ CREATE TABLE IF NOT EXISTS remissions (
     project_id INT NOT NULL,
     data JSON NOT NULL,
     pdf_path VARCHAR(255) NOT NULL,
+    recipient_type ENUM('owner','client') DEFAULT 'owner',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (project_id) REFERENCES projects(id)
 );
@@ -207,6 +208,9 @@ ALTER TABLE projects
 ALTER TABLE remissions
   ADD COLUMN owner_id INT,
   ADD CONSTRAINT FOREIGN KEY (owner_id) REFERENCES owner_companies(id);
+
+ALTER TABLE remissions
+  ADD COLUMN recipient_type ENUM('owner','client') DEFAULT 'owner';
 
 ALTER TABLE owner_companies
   ADD COLUMN profit_percentage DECIMAL(10,2) DEFAULT 0;

--- a/models/remissionsModel.js
+++ b/models/remissionsModel.js
@@ -1,15 +1,16 @@
 const db = require('../db');
 
-const createRemission = (projectId, data, pdfPath, ownerId = 1) => {
+const createRemission = (projectId, data, pdfPath, recipientType = 'owner', ownerId = 1) => {
   return new Promise((resolve, reject) => {
-    const sql = `INSERT INTO remissions (project_id, data, pdf_path, owner_id) VALUES (?, ?, ?, ?)`;
-    db.query(sql, [projectId, data, pdfPath, ownerId], (err, result) => {
+    const sql = `INSERT INTO remissions (project_id, data, pdf_path, recipient_type, owner_id) VALUES (?, ?, ?, ?, ?)`;
+    db.query(sql, [projectId, data, pdfPath, recipientType, ownerId], (err, result) => {
       if (err) return reject(err);
       resolve({
         id: result.insertId,
         project_id: projectId,
         data: JSON.parse(data),
         pdf_path: pdfPath,
+        recipient_type: recipientType,
         owner_id: ownerId
       });
     });

--- a/templates/remission_client.html
+++ b/templates/remission_client.html
@@ -66,9 +66,7 @@
         <tr>
           <th>Cantidad</th>
           <th>Descripción</th>
-          <th>Costo de inversión</th>
           <th>Costo para venta</th>
-          <th>Porcentaje</th>
         </tr>
       </thead>
       <tbody>
@@ -76,9 +74,7 @@
         <tr>
           <td class="center">{{cantidad}}</td>
           <td>{{descripcion}}</td>
-          <td class="right">{{costoInversion}}</td>
           <td class="right">{{costoVenta}}</td>
-          <td class="right">{{porcentaje}}</td>
         </tr>
         {{/conceptos}}
       </tbody>


### PR DESCRIPTION
## Summary
- add new `recipient_type` column to `remissions`
- store owner and client remissions on PDF generation
- create template for client remission without investment cost or percentage
- rename issuer label to `Nombre de proveedor`
- document database update

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a4e4d3f20832daef769c8765a1aed