### PR TITLE
Fix label in client remission template

### DIFF
--- a/templates/remission_client.html
+++ b/templates/remission_client.html
@@ -66,7 +66,7 @@
         <tr>
           <th>Cantidad</th>
           <th>Descripción</th>
-          <th>Costo para venta</th>
+          <th>Precio unitario</th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
## Summary
- update the heading for client remission template

## Testing
- `./run-tests.sh` *(fails: 403 Forbidden while running npm install)*

------
https://chatgpt.com/codex/tasks/task_e_684a53b41300832d8ce8317969e3eebd