### PR TITLE
Add installation costs update and remission generation

### DIFF
--- a/API_NODE_New.postman_collection.json
+++ b/API_NODE_New.postman_collection.json
@@ -838,6 +838,73 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "Installation Costs",
+      "item": [
+        {
+          "name": "Create Installation Cost",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{token}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"project_id\": 1,\n  \"workers\": 2,\n  \"days\": 5,\n  \"meal_per_person\": 100,\n  \"hotel_per_day\": 200,\n  \"labor_cost\": 300,\n  \"personal_transport\": 50,\n  \"local_transport\": 80,\n  \"extra_expenses\": 120\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:3000/installation-costs",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["installation-costs"]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Installation Cost",
+          "request": {
+            "method": "GET",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{token}}" }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/installation-costs?project_id=1",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["installation-costs"],
+              "query": [ { "key": "project_id", "value": "1" } ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Installation Cost",
+          "request": {
+            "method": "PUT",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{token}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"workers\": 2\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "http://localhost:3000/installation-costs/1",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["installation-costs", "1"]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ]
 }

--- a/Modules/remissionGenerator.js
+++ b/Modules/remissionGenerator.js
@@ -1,0 +1,159 @@
+const fs = require('fs');
+const path = require('path');
+const pdf = require('html-pdf');
+const Mustache = require('mustache');
+
+const Projects = require('../models/projectsModel');
+const Clients = require('../models/clientsModel');
+const OwnerCompanies = require('../models/ownerCompaniesModel');
+const PlaysetAccessories = require('../models/playsetAccessoriesModel');
+const InstallationCosts = require('../models/installationCostsModel');
+const Remissions = require('../models/remissionsModel');
+
+async function generateRemission(projectId) {
+  const project = await Projects.findById(projectId);
+  if (!project) throw new Error('Proyecto no encontrado');
+  const client = await Clients.findById(project.client_id);
+  const owner = await OwnerCompanies.findById(project.owner_id);
+
+  const costInfo = await PlaysetAccessories.calculatePlaysetCost(project.playset_id);
+  const profit_margin = owner ? +(owner.profit_percentage / 100) : 0;
+  const marginFactor = 1 + profit_margin;
+  const accessories = (costInfo ? costInfo.accessories : []).map((a) => {
+    const costWithMargin = +(a.cost * marginFactor).toFixed(2);
+    return {
+      accessory_id: a.accessory_id,
+      accessory_name: a.accessory_name,
+      quantity: a.quantity,
+      materials: a.materials,
+      investment_cost: a.cost,
+      cost_with_margin: costWithMargin
+    };
+  });
+
+  const install = await InstallationCosts.findByProjectId(project.id);
+  const installItems = [];
+  if (install) {
+    const meals = (install.meal_per_person || 0) * (install.workers || 0) * (install.days || 0);
+    const hotel = (install.hotel_per_day || 0) * (install.days || 0);
+    installItems.push(
+      { accessory_name: 'Comidas', quantity: 1, materials: [], investment_cost: meals, cost_with_margin: +(meals * marginFactor).toFixed(2) },
+      { accessory_name: 'Hotel', quantity: 1, materials: [], investment_cost: hotel, cost_with_margin: +(hotel * marginFactor).toFixed(2) },
+      { accessory_name: 'Mano de obra', quantity: 1, materials: [], investment_cost: install.labor_cost || 0, cost_with_margin: +((install.labor_cost || 0) * marginFactor).toFixed(2) },
+      { accessory_name: 'Transporte personal', quantity: 1, materials: [], investment_cost: install.personal_transport || 0, cost_with_margin: +((install.personal_transport || 0) * marginFactor).toFixed(2) },
+      { accessory_name: 'Transporte local', quantity: 1, materials: [], investment_cost: install.local_transport || 0, cost_with_margin: +((install.local_transport || 0) * marginFactor).toFixed(2) },
+      { accessory_name: 'Gastos extras', quantity: 1, materials: [], investment_cost: install.extra_expenses || 0, cost_with_margin: +((install.extra_expenses || 0) * marginFactor).toFixed(2) }
+    );
+  }
+
+  const allItems = accessories.concat(installItems);
+  const total_investment_cost = allItems.reduce((sum, acc) => sum + acc.investment_cost, 0);
+  const total_cost_with_margin = allItems.reduce((sum, acc) => sum + acc.cost_with_margin, 0);
+
+  const remissionDir = path.join(__dirname, '..', 'remissions');
+  if (!fs.existsSync(remissionDir)) {
+    fs.mkdirSync(remissionDir);
+  }
+  const timestamp = Date.now();
+  const ownerFileName = `project_${project.id}_${timestamp}_owner.pdf`;
+  const ownerFilePath = path.join(remissionDir, ownerFileName);
+  const clientFileName = `project_${project.id}_${timestamp}_client.pdf`;
+  const clientFilePath = path.join(remissionDir, clientFileName);
+
+  const snapshot = JSON.stringify({
+    project,
+    client,
+    accessories: allItems,
+    profit_margin,
+    total_investment_cost,
+    total_cost_with_margin
+  });
+
+  await Remissions.createRemission(project.id, snapshot, ownerFilePath, 'owner', 1);
+  await Remissions.createRemission(project.id, snapshot, clientFilePath, 'client', 1);
+
+  const issueDate = new Date();
+  const formattedDate = issueDate.toISOString().slice(0, 10);
+  const subtotal = total_cost_with_margin;
+  const iva = +(subtotal * 0.16).toFixed(2);
+  const total = +(subtotal + iva).toFixed(2);
+
+  const conceptos = allItems.map(acc => ({
+    cantidad: acc.quantity,
+    descripcion: acc.accessory_name,
+    costoInversion: acc.investment_cost.toFixed(2),
+    costoVenta: acc.cost_with_margin.toFixed(2),
+    porcentaje: owner ? owner.profit_percentage.toFixed(2) + '%' : '0%'
+  }));
+
+  const conceptosCliente = [
+    {
+      cantidad: 1,
+      descripcion: costInfo ? costInfo.playset_name : '',
+      costoVenta: total_cost_with_margin.toFixed(2)
+    }
+  ];
+
+  const ownerTemplatePath = path.join(__dirname, '..', 'templates', 'remission.html');
+  const ownerTemplate = fs.readFileSync(ownerTemplatePath, 'utf8');
+  const clientTemplatePath = path.join(__dirname, '..', 'templates', 'remission_client.html');
+  const clientTemplate = fs.readFileSync(clientTemplatePath, 'utf8');
+
+  const ownerHtml = Mustache.render(ownerTemplate, {
+    folio: project.id,
+    fechaEmision: formattedDate,
+    lugarExpedicion: owner ? owner.address : 'N/A',
+    logoSrc: '',
+    emisor: { razonSocial: owner ? owner.name : '' },
+    receptor: {
+      nombreCliente: client ? client.company_name : 'Cliente no registrado',
+      nombreContacto: client ? client.contact_name : '',
+      domicilio: client ? client.address : ''
+    },
+    conceptos,
+    totales: { subtotal: subtotal.toFixed(2), tasaIva: '16%', iva: iva.toFixed(2), total: total.toFixed(2), totalLetra: '' },
+    uuid: '',
+    folioFiscal: '',
+    selloSat: '',
+    selloEmisor: '',
+    cadenaOriginal: ''
+  });
+
+  const clientHtml = Mustache.render(clientTemplate, {
+    folio: project.id,
+    fechaEmision: formattedDate,
+    lugarExpedicion: owner ? owner.address : 'N/A',
+    logoSrc: '',
+    emisor: { razonSocial: owner ? owner.name : '' },
+    receptor: {
+      nombreCliente: client ? client.company_name : 'Cliente no registrado',
+      nombreContacto: client ? client.contact_name : '',
+      domicilio: client ? client.address : ''
+    },
+    conceptos: conceptosCliente,
+    totales: { subtotal: subtotal.toFixed(2), tasaIva: '16%', iva: iva.toFixed(2), total: total.toFixed(2), totalLetra: '' },
+    uuid: '',
+    folioFiscal: '',
+    selloSat: '',
+    selloEmisor: '',
+    cadenaOriginal: ''
+  });
+
+  await new Promise((resolve, reject) => {
+    pdf.create(ownerHtml).toFile(ownerFilePath, err => {
+      if (err) return reject(err);
+      resolve();
+    });
+  });
+
+  await new Promise((resolve, reject) => {
+    pdf.create(clientHtml).toFile(clientFilePath, err => {
+      if (err) return reject(err);
+      resolve();
+    });
+  });
+
+  return { ownerFilePath, clientFilePath };
+}
+
+module.exports = { generateRemission };

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ DB_NAME=demodb
 - `POST /clients` Crea un cliente (protegido).
 - `GET /projects` Lista proyectos (protegido). Incluye el nombre y descripción del playset asociado.
 - `POST /projects` Crea un proyecto con cliente y playset (protegido).
+- `POST /installation-costs` Registra los costos de instalación de un proyecto.
+- `GET /installation-costs?project_id=<id>` Obtiene los costos de instalación por proyecto.
+- `PUT /installation-costs/:project_id` Actualiza los costos de instalación.
 
 ## Ejemplo de construcción de un playset
 
@@ -64,6 +67,13 @@ curl -X POST http://localhost:3000/playset-accessories \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <token>" \
   -d '{"playsetId":1,"accessoryId":2,"quantity":1}'
+```
+
+```bash
+curl -X POST http://localhost:3000/installation-costs \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <token>" \
+  -d '{"project_id":1,"workers":2,"days":5,"meal_per_person":100,"hotel_per_day":200,"labor_cost":300,"personal_transport":50,"local_transport":80,"extra_expenses":120}'
 ```
 
 Puedes usar `API_NODE_Scenario.postman_collection.json` como referencia para

--- a/models/installationCostsModel.js
+++ b/models/installationCostsModel.js
@@ -44,7 +44,29 @@ const findByProjectId = (projectId) => {
   });
 };
 
+const updateInstallationCosts = (
+  projectId,
+  workers,
+  days,
+  mealPerPerson,
+  hotelPerDay,
+  laborCost,
+  personalTransport,
+  localTransport,
+  extraExpenses
+) => {
+  return new Promise((resolve, reject) => {
+    const sql = `UPDATE installation_costs SET workers = ?, days = ?, meal_per_person = ?, hotel_per_day = ?, labor_cost = ?, personal_transport = ?, local_transport = ?, extra_expenses = ? WHERE project_id = ?`;
+    const params = [workers, days, mealPerPerson, hotelPerDay, laborCost, personalTransport, localTransport, extraExpenses, projectId];
+    db.query(sql, params, (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
 module.exports = {
   createInstallationCosts,
-  findByProjectId
+  findByProjectId,
+  updateInstallationCosts
 };

--- a/models/remissionsModel.js
+++ b/models/remissionsModel.js
@@ -35,8 +35,19 @@ const findAll = () => {
   });
 };
 
+const findByProjectId = (projectId) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'SELECT * FROM remissions WHERE project_id = ?';
+    db.query(sql, [projectId], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+};
+
 module.exports = {
   createRemission,
   findById,
-  findAll
+  findAll,
+  findByProjectId
 };

--- a/routes/installationCosts.js
+++ b/routes/installationCosts.js
@@ -1,5 +1,7 @@
 const express = require('express');
 const InstallationCosts = require('../models/installationCostsModel');
+const Remissions = require('../models/remissionsModel');
+const { generateRemission } = require('../Modules/remissionGenerator');
 const router = express.Router();
 
 /**
@@ -34,6 +36,16 @@ const router = express.Router();
  *                 type: number
  *               extra_expenses:
  *                 type: number
+ *           example:
+ *             project_id: 1
+ *             workers: 2
+ *             days: 5
+ *             meal_per_person: 100
+ *             hotel_per_day: 200
+ *             labor_cost: 300
+ *             personal_transport: 50
+ *             local_transport: 80
+ *             extra_expenses: 120
  *   get:
  *     summary: Obtener costos de instalación por proyecto
  *     tags:
@@ -57,6 +69,10 @@ router.post('/installation-costs', async (req, res) => {
       local_transport,
       extra_expenses
     } = req.body;
+    const existing = await InstallationCosts.findByProjectId(project_id);
+    if (existing) {
+      return res.status(400).json({ message: 'El proyecto ya tiene costos registrados' });
+    }
     const record = await InstallationCosts.createInstallationCosts(
       project_id,
       workers,
@@ -69,6 +85,16 @@ router.post('/installation-costs', async (req, res) => {
       extra_expenses,
       1
     );
+
+    const remissions = await Remissions.findByProjectId(project_id);
+    if (remissions.length) {
+      try {
+        await generateRemission(project_id);
+      } catch (err) {
+        console.error('Error generating remission:', err);
+      }
+    }
+
     res.status(201).json(record);
   } catch (error) {
     res.status(500).json({ message: error.message });
@@ -84,6 +110,86 @@ router.get('/installation-costs', async (req, res) => {
     const record = await InstallationCosts.findByProjectId(project_id);
     if (!record) return res.status(404).json({ message: 'No encontrado' });
     res.json(record);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+/**
+ * @openapi
+ * /installation-costs/{project_id}:
+ *   put:
+ *     summary: Actualizar costos de instalación
+ *     tags:
+ *       - InstallationCosts
+ *     parameters:
+ *       - in: path
+ *         name: project_id
+ *         schema:
+ *           type: integer
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               workers:
+ *                 type: integer
+ *               days:
+ *                 type: integer
+ *               meal_per_person:
+ *                 type: number
+ *               hotel_per_day:
+ *                 type: number
+ *               labor_cost:
+ *                 type: number
+ *               personal_transport:
+ *                 type: number
+ *               local_transport:
+ *                 type: number
+ *               extra_expenses:
+ *                 type: number
+ */
+router.put('/installation-costs/:project_id', async (req, res) => {
+  try {
+    const { project_id } = req.params;
+    const existing = await InstallationCosts.findByProjectId(project_id);
+    if (!existing) {
+      return res.status(404).json({ message: 'No encontrado' });
+    }
+    const {
+      workers,
+      days,
+      meal_per_person,
+      hotel_per_day,
+      labor_cost,
+      personal_transport,
+      local_transport,
+      extra_expenses
+    } = req.body;
+    await InstallationCosts.updateInstallationCosts(
+      project_id,
+      workers,
+      days,
+      meal_per_person,
+      hotel_per_day,
+      labor_cost,
+      personal_transport,
+      local_transport,
+      extra_expenses
+    );
+
+    const remissions = await Remissions.findByProjectId(project_id);
+    if (remissions.length) {
+      try {
+        await generateRemission(project_id);
+      } catch (err) {
+        console.error('Error generating remission:', err);
+      }
+    }
+
+    res.json({ message: 'Actualizado' });
   } catch (error) {
     res.status(500).json({ message: error.message });
   }


### PR DESCRIPTION
## Summary
- handle creating and updating installation costs for projects
- generate new remissions when installation costs change
- expose update functions in models
- provide helper for generating remissions
- document new endpoints and add postman examples
- show full body example for installation cost creation in Postman and README

## Testing
- `npm test` *(fails: mocha not found)*
- `./run-tests.sh` *(fails: 403 Forbidden while installing html-pdf)*

------
https://chatgpt.com/codex/tasks/task_e_684a552639cc832d85bd5b10ad7c6e80