### PR TITLE
Add company logo upload

### DIFF
--- a/API_NODE.postman_collection.json
+++ b/API_NODE.postman_collection.json
@@ -577,6 +577,32 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "Owner Companies",
+      "item": [
+        {
+          "name": "Upload Logo",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                { "key": "file", "type": "file", "src": "" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:3000/owner-companies/1/logo",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["owner-companies", "1", "logo"]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ]
 }

--- a/API_NODE_New.postman_collection.json
+++ b/API_NODE_New.postman_collection.json
@@ -905,6 +905,34 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "Owner Companies",
+      "item": [
+        {
+          "name": "Upload Logo",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Authorization", "value": "Bearer {{token}}" }
+            ],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                { "key": "file", "type": "file", "src": "" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:3000/owner-companies/1/logo",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["owner-companies", "1", "logo"]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ]
 }

--- a/API_NODE_Scenario.postman_collection.json
+++ b/API_NODE_Scenario.postman_collection.json
@@ -708,6 +708,32 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "Owner Companies",
+      "item": [
+        {
+          "name": "Upload Logo",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                { "key": "file", "type": "file", "src": "" }
+              ]
+            },
+            "url": {
+              "raw": "http://localhost:3000/owner-companies/1/logo",
+              "protocol": "http",
+              "host": ["localhost"],
+              "port": "3000",
+              "path": ["owner-companies", "1", "logo"]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ]
 }

--- a/Modules/remissionGenerator.js
+++ b/Modules/remissionGenerator.js
@@ -103,7 +103,7 @@ async function generateRemission(projectId) {
     folio: project.id,
     fechaEmision: formattedDate,
     lugarExpedicion: owner ? owner.address : 'N/A',
-    logoSrc: '',
+    logoSrc: owner && owner.logo_path ? owner.logo_path : '',
     emisor: { razonSocial: owner ? owner.name : '' },
     receptor: {
       nombreCliente: client ? client.company_name : 'Cliente no registrado',
@@ -123,7 +123,7 @@ async function generateRemission(projectId) {
     folio: project.id,
     fechaEmision: formattedDate,
     lugarExpedicion: owner ? owner.address : 'N/A',
-    logoSrc: '',
+    logoSrc: owner && owner.logo_path ? owner.logo_path : '',
     emisor: { razonSocial: owner ? owner.name : '' },
     receptor: {
       nombreCliente: client ? client.company_name : 'Cliente no registrado',

--- a/api.js
+++ b/api.js
@@ -23,6 +23,7 @@ const accessoryMaterialsRouter = require('./routes/accessoryMaterials');
 const clientsRouter = require('./routes/clients');
 const projectsRouter = require('./routes/projects');
 const installationCostsRouter = require('./routes/installationCosts');
+const ownerCompaniesRouter = require('./routes/ownerCompanies');
 
 const app = express();
 app.use(passport.initialize());
@@ -87,6 +88,7 @@ app.use('/', authenticateJWT, materialAttributesRouter);
 app.use('/', authenticateJWT, clientsRouter);
 app.use('/', authenticateJWT, projectsRouter);
 app.use('/', authenticateJWT, installationCostsRouter);
+app.use('/', authenticateJWT, ownerCompaniesRouter);
 
 // Middleware para manejar errores
 app.use((err, req, res, next) => {

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -232,3 +232,6 @@ ALTER TABLE remissions
 
 ALTER TABLE owner_companies
   ADD COLUMN profit_percentage DECIMAL(10,2) DEFAULT 0;
+
+ALTER TABLE owner_companies
+  ADD COLUMN logo_path VARCHAR(255);

--- a/models/ownerCompaniesModel.js
+++ b/models/ownerCompaniesModel.js
@@ -1,12 +1,12 @@
 const db = require('../db');
 
-const createOwnerCompany = (name, address, profitPercentage = 0) => {
+const createOwnerCompany = (name, address, profitPercentage = 0, logoPath = null) => {
   return new Promise((resolve, reject) => {
     const sql =
-      `INSERT INTO owner_companies (name, address, profit_percentage) VALUES (?, ?, ?)`;
-    db.query(sql, [name, address, profitPercentage], (err, result) => {
+      `INSERT INTO owner_companies (name, address, profit_percentage, logo_path) VALUES (?, ?, ?, ?)`;
+    db.query(sql, [name, address, profitPercentage, logoPath], (err, result) => {
       if (err) return reject(err);
-      resolve({ id: result.insertId, name, address, profit_percentage: profitPercentage });
+      resolve({ id: result.insertId, name, address, profit_percentage: profitPercentage, logo_path: logoPath });
     });
   });
 };
@@ -29,11 +29,21 @@ const findAll = () => {
   });
 };
 
-const updateOwnerCompany = (id, name, address, profitPercentage) => {
+const updateOwnerCompany = (id, name, address, profitPercentage, logoPath = null) => {
   return new Promise((resolve, reject) => {
     const sql =
-      `UPDATE owner_companies SET name = ?, address = ?, profit_percentage = ? WHERE id = ?`;
-    db.query(sql, [name, address, profitPercentage, id], (err, result) => {
+      `UPDATE owner_companies SET name = ?, address = ?, profit_percentage = ?, logo_path = ? WHERE id = ?`;
+    db.query(sql, [name, address, profitPercentage, logoPath, id], (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+const updateLogoPath = (id, logoPath) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'UPDATE owner_companies SET logo_path = ? WHERE id = ?';
+    db.query(sql, [logoPath, id], (err, result) => {
       if (err) return reject(err);
       resolve(result);
     });
@@ -63,6 +73,7 @@ module.exports = {
   findById,
   findAll,
   updateOwnerCompany,
+  updateLogoPath,
   deleteOwnerCompany,
   getFirst
 };

--- a/routes/ownerCompanies.js
+++ b/routes/ownerCompanies.js
@@ -1,0 +1,79 @@
+const express = require('express');
+const router = express.Router();
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+const OwnerCompanies = require('../models/ownerCompaniesModel');
+
+/**
+ * Ruta de la carpeta donde se guardarán los archivos
+ */
+const uploadDirectory = './uploads';
+if (!fs.existsSync(uploadDirectory)) {
+  fs.mkdirSync(uploadDirectory);
+}
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => {
+    cb(null, uploadDirectory);
+  },
+  filename: (req, file, cb) => {
+    cb(null, Date.now() + path.extname(file.originalname));
+  }
+});
+
+const upload = multer({
+  storage,
+  limits: { fileSize: 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    const fileTypes = /jpeg|jpg|png/;
+    const extname = fileTypes.test(path.extname(file.originalname).toLowerCase());
+    const mimetype = fileTypes.test(file.mimetype);
+    if (extname && mimetype) {
+      cb(null, true);
+    } else {
+      cb('Error: Solo se permiten imágenes (jpeg, jpg, png)');
+    }
+  }
+});
+
+/**
+ * @openapi
+ * /owner-companies/{id}/logo:
+ *   post:
+ *     summary: Subir logo de la empresa
+ *     tags:
+ *       - OwnerCompanies
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               file:
+ *                 type: string
+ *                 format: binary
+ *     responses:
+ *       200:
+ *         description: Logo actualizado
+ */
+router.post('/owner-companies/:id/logo', upload.single('file'), async (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ message: 'No se proporcionó ningún archivo' });
+  }
+  try {
+    const fileUrl = `${req.protocol}://${req.get('host')}/${req.file.path}`;
+    await OwnerCompanies.updateLogoPath(req.params.id, fileUrl);
+    res.json({ message: 'Logo actualizado', logoPath: fileUrl });
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+module.exports = router;

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -334,7 +334,7 @@ router.get('/projects/:id/pdf', async (req, res) => {
       folio: project.id,
       fechaEmision: formattedDate,
       lugarExpedicion: owner ? owner.address : 'N/A',
-      logoSrc: '',
+      logoSrc: owner && owner.logo_path ? owner.logo_path : '',
       emisor: { razonSocial: owner ? owner.name : '' },
       receptor: {
         nombreCliente: client ? client.company_name : 'Cliente no registrado',
@@ -354,7 +354,7 @@ router.get('/projects/:id/pdf', async (req, res) => {
       folio: project.id,
       fechaEmision: formattedDate,
       lugarExpedicion: owner ? owner.address : 'N/A',
-      logoSrc: '',
+      logoSrc: owner && owner.logo_path ? owner.logo_path : '',
       emisor: { razonSocial: owner ? owner.name : '' },
       receptor: {
         nombreCliente: client ? client.company_name : 'Cliente no registrado',

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -6,6 +6,7 @@ const playsetAccessories = require('../models/playsetAccessoriesModel');
 const clients = require('../models/clientsModel');
 const projects = require('../models/projectsModel');
 const installationCosts = require('../models/installationCostsModel');
+const ownerCompanies = require('../models/ownerCompaniesModel');
 
 describe('Model exports', () => {
   it('materials model exposes CRUD functions', () => {
@@ -45,6 +46,10 @@ describe('Model exports', () => {
   it('installationCosts model exposes basic functions', () => {
     expect(installationCosts.createInstallationCosts).to.be.a('function');
     expect(installationCosts.findByProjectId).to.be.a('function');
+  });
+
+  it('ownerCompanies model exposes update logo function', () => {
+    expect(ownerCompanies.updateLogoPath).to.be.a('function');
   });
 });
 

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -8,6 +8,7 @@ const playsetAccessoriesRouter = require('../routes/playsetAccessories');
 const clientsRouter = require('../routes/clients');
 const projectsRouter = require('../routes/projects');
 const installationCostsRouter = require('../routes/installationCosts');
+const ownerCompaniesRouter = require('../routes/ownerCompanies');
 
 describe('Route definitions', () => {
   it('materials router has routes configured', () => {
@@ -58,5 +59,9 @@ describe('Route definitions', () => {
 
   it('installation costs router has routes configured', () => {
     expect(installationCostsRouter.stack).to.be.an('array').that.is.not.empty;
+  });
+
+  it('owner companies router has routes configured', () => {
+    expect(ownerCompaniesRouter.stack).to.be.an('array').that.is.not.empty;
   });
 });


### PR DESCRIPTION
## Summary
- allow storing company logo path
- generate PDFs with company logo
- upload company logo via `/owner-companies/:id/logo`
- expose logo API in Postman collections
- cover new route and model in tests

## Testing
- `./run-tests.sh` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html-pdf)*

------
https://chatgpt.com/codex/tasks/task_e_684adf4145ac832d995ad39f4c814a0f