### PR TITLE
Remove profit_margin from requests

### DIFF
--- a/API_NODE.postman_collection.json
+++ b/API_NODE.postman_collection.json
@@ -555,7 +555,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"playset_id\": 1,\n  \"profit_margin\": 0.2,\n  \"client\": {\n    \"id\": 1\n  }\n}",
+              "raw": "{\n  \"playset_id\": 1,\n  \"client\": {\n    \"id\": 1\n  }\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/API_NODE_New.postman_collection.json
+++ b/API_NODE_New.postman_collection.json
@@ -824,7 +824,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"playset_id\": 1,\n  \"profit_margin\": 0.2,\n  \"client\": {\n    \"id\": 1\n  }\n}",
+              "raw": "{\n  \"playset_id\": 1,\n  \"client\": {\n    \"id\": 1\n  }\n}",
               "options": { "raw": { "language": "json" } }
             },
             "url": {

--- a/API_NODE_Scenario.postman_collection.json
+++ b/API_NODE_Scenario.postman_collection.json
@@ -686,7 +686,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"playset_id\": 1,\n  \"profit_margin\": 0.2,\n  \"client\": {\n    \"id\": 1\n  }\n}",
+              "raw": "{\n  \"playset_id\": 1,\n  \"client\": {\n    \"id\": 1\n  }\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -34,8 +34,6 @@ const router = express.Router();
  *             properties:
  *               playset_id:
  *                 type: integer
- *               profit_margin:
- *                 type: number
  *               contact_email:
  *                 type: string
  *               client:


### PR DESCRIPTION
## Summary
- update swagger docs for projects
- remove `profit_margin` from Postman examples

## Testing
- `./run-tests.sh` *(fails: 403 Forbidden to npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_684ae20dff44832dadd88e3b6433647b