### PR TITLE
Fix logo display in remission PDFs

### DIFF
--- a/api.js
+++ b/api.js
@@ -38,6 +38,9 @@ app.use(cookieParser());
 
 app.use(bodyParser.json());
 
+// Serve uploaded files so templates can access logos
+app.use('/uploads', express.static('uploads'));
+
 // Documentación Swagger
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 


### PR DESCRIPTION
## Summary
- serve uploaded files in `uploads` so PDFs can include company logos

## Testing
- `./run-tests.sh` *(fails: 403 Forbidden on npm install)*

------
https://chatgpt.com/codex/tasks/task_e_684ae24b6580832db05577f6a0e9a2fe