### PR TITLE
Fix text wrapping for expedition location

### DIFF
--- a/templates/remission.html
+++ b/templates/remission.html
@@ -14,7 +14,8 @@
     th{background:#f0f0f0;font-weight:600}
     .right{text-align:right}
     .center{text-align:center}
-    .small{font-size:10px}
+    /* Allow long texts to wrap within the column */
+    .small{font-size:10px;word-break:break-word;white-space:pre-line}
     .section{margin-top:16px}
     .row{display:flex;justify-content:space-between}
     .col{flex:1}

--- a/templates/remission_client.html
+++ b/templates/remission_client.html
@@ -14,7 +14,8 @@
     th{background:#f0f0f0;font-weight:600}
     .right{text-align:right}
     .center{text-align:center}
-    .small{font-size:10px}
+    /* Allow long texts to wrap within the column */
+    .small{font-size:10px;word-break:break-word;white-space:pre-line}
     .section{margin-top:16px}
     .row{display:flex;justify-content:space-between}
     .col{flex:1}


### PR DESCRIPTION
## Summary
- allow long text wrapping in remission templates

## Testing
- `./run-tests.sh` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html-pdf)*

------
https://chatgpt.com/codex/tasks/task_e_684ae4488924832d9532c378a3013acb