### PR TITLE
Fix text wrapping for expedition location

### DIFF
--- a/templates/remission.html
+++ b/templates/remission.html
@@ -14,9 +14,12 @@
     th{background:#f0f0f0;font-weight:600}
     .right{text-align:right}
     .center{text-align:center}
-    .small{font-size:10px}
+    /* Allow long texts to wrap within the column */
+    .small{font-size:10px;word-break:break-word;white-space:pre-line}
+    /* Limit header fields like Lugar de expedición to two lines */
+    .clamp{overflow:hidden;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical}
     .section{margin-top:16px}
-    .row{display:flex;justify-content:space-between}
+    .row{display:flex;justify-content:space-between;align-items:flex-start}
     .col{flex:1}
     .stamp{border:1px dashed #888;padding:6px;font-size:10px}
     /* Separadores */
@@ -30,7 +33,7 @@
       <h1>REMISIÓN</h1>
       <p class="small">Folio Interno: <strong>{{folio}}</strong></p>
       <p class="small">Fecha de emisión: <strong>{{fechaEmision}}</strong></p>
-      <p class="small">Lugar de expedición: <strong>{{lugarExpedicion}}</strong></p>
+      <p class="small clamp">Lugar de expedición: <strong>{{lugarExpedicion}}</strong></p>
     </div>
     <div class="col right">
       <!-- Logo (opcional) -->

--- a/templates/remission_client.html
+++ b/templates/remission_client.html
@@ -14,9 +14,12 @@
     th{background:#f0f0f0;font-weight:600}
     .right{text-align:right}
     .center{text-align:center}
-    .small{font-size:10px}
+    /* Allow long texts to wrap within the column */
+    .small{font-size:10px;word-break:break-word;white-space:pre-line}
+    /* Limit header fields like Lugar de expedición to two lines */
+    .clamp{overflow:hidden;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical}
     .section{margin-top:16px}
-    .row{display:flex;justify-content:space-between}
+    .row{display:flex;justify-content:space-between;align-items:flex-start}
     .col{flex:1}
     .stamp{border:1px dashed #888;padding:6px;font-size:10px}
     /* Separadores */
@@ -30,7 +33,7 @@
       <h1>REMISIÓN</h1>
       <p class="small">Folio Interno: <strong>{{folio}}</strong></p>
       <p class="small">Fecha de emisión: <strong>{{fechaEmision}}</strong></p>
-      <p class="small">Lugar de expedición: <strong>{{lugarExpedicion}}</strong></p>
+      <p class="small clamp">Lugar de expedición: <strong>{{lugarExpedicion}}</strong></p>
     </div>
     <div class="col right">
       <!-- Logo (opcional) -->


### PR DESCRIPTION
## Summary
- allow long text wrapping in remission templates
- keep logo top-aligned with header data

## Testing
- `./run-tests.sh` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html-pdf)*

------
https://chatgpt.com/codex/tasks/task_e_684ae4488924832d9532c378a3013acb