### PR TITLE
Add remission style endpoint to Postman collections

### DIFF
--- a/API_NODE.postman_collection.json
+++ b/API_NODE.postman_collection.json
@@ -515,36 +515,36 @@
               ]
             }
           },
-        "response": []
-      },
-      {
-        "name": "Get Project PDF",
-        "request": {
-          "method": "GET",
-          "header": [
-            {
-              "key": "Authorization",
-              "value": "Bearer {{token}}"
-            }
-          ],
-          "url": {
-            "raw": "http://localhost:3000/projects/1/pdf",
-            "protocol": "http",
-            "host": [
-              "localhost"
-            ],
-            "port": "3000",
-            "path": [
-              "projects",
-              "1",
-              "pdf"
-            ]
-          }
+          "response": []
         },
-        "response": []
-      },
-      {
-        "name": "Create Project",
+        {
+          "name": "Get Project PDF",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/projects/1/pdf",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "projects",
+                "1",
+                "pdf"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Project",
           "request": {
             "method": "POST",
             "header": [
@@ -589,15 +589,91 @@
             "body": {
               "mode": "formdata",
               "formdata": [
-                { "key": "file", "type": "file", "src": "" }
+                {
+                  "key": "file",
+                  "type": "file",
+                  "src": ""
+                }
               ]
             },
             "url": {
               "raw": "http://localhost:3000/owner-companies/1/logo",
               "protocol": "http",
-              "host": ["localhost"],
+              "host": [
+                "localhost"
+              ],
               "port": "3000",
-              "path": ["owner-companies", "1", "logo"]
+              "path": [
+                "owner-companies",
+                "1",
+                "logo"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Remission Style",
+      "item": [
+        {
+          "name": "Get Remission Style",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/remission-style",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "remission-style"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Remission Style",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"headerBackgroundColor\": \"#ffffff\",\n  \"headerTextColor\": \"#000000\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "http://localhost:3000/remission-style",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "remission-style"
+              ]
             }
           },
           "response": []

--- a/API_NODE_New.postman_collection.json
+++ b/API_NODE_New.postman_collection.json
@@ -725,14 +725,21 @@
           "request": {
             "method": "GET",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{token}}" }
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
             ],
             "url": {
               "raw": "http://localhost:3000/clients",
               "protocol": "http",
-              "host": ["localhost"],
+              "host": [
+                "localhost"
+              ],
               "port": "3000",
-              "path": ["clients"]
+              "path": [
+                "clients"
+              ]
             }
           },
           "response": []
@@ -742,19 +749,30 @@
           "request": {
             "method": "POST",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{token}}" }
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
             ],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"contact_name\": \"John\",\n  \"company_name\": \"Acme Inc\",\n  \"address\": \"Address\",\n  \"requires_invoice\": true,\n  \"billing_info\": \"RFC\"\n}",
-              "options": { "raw": { "language": "json" } }
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
             },
             "url": {
               "raw": "http://localhost:3000/clients",
               "protocol": "http",
-              "host": ["localhost"],
+              "host": [
+                "localhost"
+              ],
               "port": "3000",
-              "path": ["clients"]
+              "path": [
+                "clients"
+              ]
             }
           },
           "response": []
@@ -764,75 +782,110 @@
     {
       "name": "Projects",
       "item": [
-       {
-         "name": "List Projects",
-         "request": {
-           "method": "GET",
+        {
+          "name": "List Projects",
+          "request": {
+            "method": "GET",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{token}}" }
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
             ],
             "url": {
               "raw": "http://localhost:3000/projects",
               "protocol": "http",
-              "host": ["localhost"],
+              "host": [
+                "localhost"
+              ],
               "port": "3000",
-              "path": ["projects"]
+              "path": [
+                "projects"
+              ]
             }
           },
-         "response": []
-       },
+          "response": []
+        },
         {
           "name": "Get Project",
           "request": {
             "method": "GET",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{token}}" }
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
             ],
             "url": {
               "raw": "http://localhost:3000/projects/1",
               "protocol": "http",
-              "host": ["localhost"],
+              "host": [
+                "localhost"
+              ],
               "port": "3000",
-              "path": ["projects", "1"]
+              "path": [
+                "projects",
+                "1"
+              ]
             }
           },
-        "response": []
-      },
-      {
-        "name": "Get Project PDF",
-        "request": {
-          "method": "GET",
-          "header": [
-            { "key": "Authorization", "value": "Bearer {{token}}" }
-          ],
-          "url": {
-            "raw": "http://localhost:3000/projects/1/pdf",
-            "protocol": "http",
-            "host": ["localhost"],
-            "port": "3000",
-            "path": ["projects", "1", "pdf"]
-          }
+          "response": []
         },
-        "response": []
-      },
-      {
-        "name": "Create Project",
+        {
+          "name": "Get Project PDF",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/projects/1/pdf",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "projects",
+                "1",
+                "pdf"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Project",
           "request": {
             "method": "POST",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{token}}" }
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
             ],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"playset_id\": 1,\n  \"client\": {\n    \"id\": 1\n  }\n}",
-              "options": { "raw": { "language": "json" } }
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
             },
             "url": {
               "raw": "http://localhost:3000/projects",
               "protocol": "http",
-              "host": ["localhost"],
+              "host": [
+                "localhost"
+              ],
               "port": "3000",
-              "path": ["projects"]
+              "path": [
+                "projects"
+              ]
             }
           },
           "response": []
@@ -847,19 +900,30 @@
           "request": {
             "method": "POST",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{token}}" }
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
             ],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"project_id\": 1,\n  \"workers\": 2,\n  \"days\": 5,\n  \"meal_per_person\": 100,\n  \"hotel_per_day\": 200,\n  \"labor_cost\": 300,\n  \"personal_transport\": 50,\n  \"local_transport\": 80,\n  \"extra_expenses\": 120\n}",
-              "options": { "raw": { "language": "json" } }
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
             },
             "url": {
               "raw": "http://localhost:3000/installation-costs",
               "protocol": "http",
-              "host": ["localhost"],
+              "host": [
+                "localhost"
+              ],
               "port": "3000",
-              "path": ["installation-costs"]
+              "path": [
+                "installation-costs"
+              ]
             }
           },
           "response": []
@@ -869,15 +933,27 @@
           "request": {
             "method": "GET",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{token}}" }
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
             ],
             "url": {
               "raw": "http://localhost:3000/installation-costs?project_id=1",
               "protocol": "http",
-              "host": ["localhost"],
+              "host": [
+                "localhost"
+              ],
               "port": "3000",
-              "path": ["installation-costs"],
-              "query": [ { "key": "project_id", "value": "1" } ]
+              "path": [
+                "installation-costs"
+              ],
+              "query": [
+                {
+                  "key": "project_id",
+                  "value": "1"
+                }
+              ]
             }
           },
           "response": []
@@ -887,19 +963,31 @@
           "request": {
             "method": "PUT",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{token}}" }
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
             ],
             "body": {
               "mode": "raw",
               "raw": "{\n  \"workers\": 2\n}",
-              "options": { "raw": { "language": "json" } }
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
             },
             "url": {
               "raw": "http://localhost:3000/installation-costs/1",
               "protocol": "http",
-              "host": ["localhost"],
+              "host": [
+                "localhost"
+              ],
               "port": "3000",
-              "path": ["installation-costs", "1"]
+              "path": [
+                "installation-costs",
+                "1"
+              ]
             }
           },
           "response": []
@@ -914,20 +1002,99 @@
           "request": {
             "method": "POST",
             "header": [
-              { "key": "Authorization", "value": "Bearer {{token}}" }
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
             ],
             "body": {
               "mode": "formdata",
               "formdata": [
-                { "key": "file", "type": "file", "src": "" }
+                {
+                  "key": "file",
+                  "type": "file",
+                  "src": ""
+                }
               ]
             },
             "url": {
               "raw": "http://localhost:3000/owner-companies/1/logo",
               "protocol": "http",
-              "host": ["localhost"],
+              "host": [
+                "localhost"
+              ],
               "port": "3000",
-              "path": ["owner-companies", "1", "logo"]
+              "path": [
+                "owner-companies",
+                "1",
+                "logo"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Remission Style",
+      "item": [
+        {
+          "name": "Get Remission Style",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/remission-style",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "remission-style"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Remission Style",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"headerBackgroundColor\": \"#ffffff\",\n  \"headerTextColor\": \"#000000\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "http://localhost:3000/remission-style",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "remission-style"
+              ]
             }
           },
           "response": []

--- a/API_NODE_Scenario.postman_collection.json
+++ b/API_NODE_Scenario.postman_collection.json
@@ -599,10 +599,10 @@
     {
       "name": "Projects",
       "item": [
-       {
-         "name": "List Projects",
-         "request": {
-           "method": "GET",
+        {
+          "name": "List Projects",
+          "request": {
+            "method": "GET",
             "header": [
               {
                 "key": "Authorization",
@@ -621,8 +621,8 @@
               ]
             }
           },
-         "response": []
-       },
+          "response": []
+        },
         {
           "name": "Get Project",
           "request": {
@@ -646,36 +646,36 @@
               ]
             }
           },
-        "response": []
-      },
-      {
-        "name": "Get Project PDF",
-        "request": {
-          "method": "GET",
-          "header": [
-            {
-              "key": "Authorization",
-              "value": "Bearer {{token}}"
-            }
-          ],
-          "url": {
-            "raw": "http://localhost:3000/projects/1/pdf",
-            "protocol": "http",
-            "host": [
-              "localhost"
-            ],
-            "port": "3000",
-            "path": [
-              "projects",
-              "1",
-              "pdf"
-            ]
-          }
+          "response": []
         },
-        "response": []
-      },
-      {
-        "name": "Create Project",
+        {
+          "name": "Get Project PDF",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/projects/1/pdf",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "projects",
+                "1",
+                "pdf"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Project",
           "request": {
             "method": "POST",
             "header": [
@@ -720,15 +720,91 @@
             "body": {
               "mode": "formdata",
               "formdata": [
-                { "key": "file", "type": "file", "src": "" }
+                {
+                  "key": "file",
+                  "type": "file",
+                  "src": ""
+                }
               ]
             },
             "url": {
               "raw": "http://localhost:3000/owner-companies/1/logo",
               "protocol": "http",
-              "host": ["localhost"],
+              "host": [
+                "localhost"
+              ],
               "port": "3000",
-              "path": ["owner-companies", "1", "logo"]
+              "path": [
+                "owner-companies",
+                "1",
+                "logo"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
+    },
+    {
+      "name": "Remission Style",
+      "item": [
+        {
+          "name": "Get Remission Style",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/remission-style",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "remission-style"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Update Remission Style",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"headerBackgroundColor\": \"#ffffff\",\n  \"headerTextColor\": \"#000000\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "http://localhost:3000/remission-style",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "remission-style"
+              ]
             }
           },
           "response": []

--- a/Modules/remissionGenerator.js
+++ b/Modules/remissionGenerator.js
@@ -10,6 +10,7 @@ const OwnerCompanies = require('../models/ownerCompaniesModel');
 const PlaysetAccessories = require('../models/playsetAccessoriesModel');
 const InstallationCosts = require('../models/installationCostsModel');
 const Remissions = require('../models/remissionsModel');
+const { getStyle } = require('./styleConfig');
 
 async function generateRemission(projectId) {
   const project = await Projects.findById(projectId);
@@ -99,6 +100,7 @@ async function generateRemission(projectId) {
   const ownerTemplate = fs.readFileSync(ownerTemplatePath, 'utf8');
   const clientTemplatePath = path.join(__dirname, '..', 'templates', 'remission_client.html');
   const clientTemplate = fs.readFileSync(clientTemplatePath, 'utf8');
+  const { headerBackgroundColor, headerTextColor } = getStyle();
 
   const ownerHtml = Mustache.render(ownerTemplate, {
     folio: project.id,
@@ -117,7 +119,9 @@ async function generateRemission(projectId) {
     folioFiscal: '',
     selloSat: '',
     selloEmisor: '',
-    cadenaOriginal: ''
+    cadenaOriginal: '',
+    headerBackgroundColor,
+    headerTextColor
   });
 
   const clientHtml = Mustache.render(clientTemplate, {
@@ -137,7 +141,9 @@ async function generateRemission(projectId) {
     folioFiscal: '',
     selloSat: '',
     selloEmisor: '',
-    cadenaOriginal: ''
+    cadenaOriginal: '',
+    headerBackgroundColor,
+    headerTextColor
   });
 
   await new Promise((resolve, reject) => {

--- a/Modules/styleConfig.js
+++ b/Modules/styleConfig.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+
+const stylePath = path.join(__dirname, '..', 'config', 'remissionStyle.json');
+const defaultStyle = {
+  headerBackgroundColor: '#f0f0f0',
+  headerTextColor: '#000000'
+};
+
+function getStyle() {
+  if (!fs.existsSync(stylePath)) return defaultStyle;
+  try {
+    const data = fs.readFileSync(stylePath, 'utf8');
+    return { ...defaultStyle, ...JSON.parse(data) };
+  } catch (err) {
+    return defaultStyle;
+  }
+}
+
+function saveStyle(newStyle) {
+  const style = { ...getStyle(), ...newStyle };
+  fs.writeFileSync(stylePath, JSON.stringify(style, null, 2));
+  return style;
+}
+
+module.exports = { getStyle, saveStyle };

--- a/README.md
+++ b/README.md
@@ -116,3 +116,17 @@ Si ya tienes datos y sólo quieres aplicar el cambio ejecuta:
 ```sql
 ALTER TABLE remissions ADD COLUMN recipient_type ENUM('owner','client') DEFAULT 'owner';
 ```
+
+## Personalización de colores en remisiones
+
+Puedes modificar el color de fondo y el color de texto de las cabeceras en las remisiones mediante el endpoint:
+
+```http
+PUT /remission-style
+```
+
+En el cuerpo envía los campos `headerBackgroundColor` y/o `headerTextColor` en formato hexadecimal. Para obtener los valores actuales utiliza:
+
+```http
+GET /remission-style
+```

--- a/api.js
+++ b/api.js
@@ -24,6 +24,7 @@ const clientsRouter = require('./routes/clients');
 const projectsRouter = require('./routes/projects');
 const installationCostsRouter = require('./routes/installationCosts');
 const ownerCompaniesRouter = require('./routes/ownerCompanies');
+const remissionStyleRouter = require('./routes/remissionStyle');
 
 const app = express();
 app.use(passport.initialize());
@@ -92,6 +93,7 @@ app.use('/', authenticateJWT, clientsRouter);
 app.use('/', authenticateJWT, projectsRouter);
 app.use('/', authenticateJWT, installationCostsRouter);
 app.use('/', authenticateJWT, ownerCompaniesRouter);
+app.use('/', authenticateJWT, remissionStyleRouter);
 
 // Middleware para manejar errores
 app.use((err, req, res, next) => {

--- a/config/remissionStyle.json
+++ b/config/remissionStyle.json
@@ -1,0 +1,4 @@
+{
+  "headerBackgroundColor": "#f0f0f0",
+  "headerTextColor": "#000000"
+}

--- a/routes/projects.js
+++ b/routes/projects.js
@@ -10,6 +10,7 @@ const fs = require('fs');
 const path = require('path');
 const OwnerCompanies = require('../models/ownerCompaniesModel');
 const numeroALetras = require('../Modules/numeroALetras');
+const { getStyle } = require('../Modules/styleConfig');
 const router = express.Router();
 
 /**
@@ -328,6 +329,7 @@ router.get('/projects/:id/pdf', async (req, res) => {
     const ownerTemplate = fs.readFileSync(ownerTemplatePath, 'utf8');
     const clientTemplatePath = path.join(__dirname, '..', 'templates', 'remission_client.html');
     const clientTemplate = fs.readFileSync(clientTemplatePath, 'utf8');
+    const { headerBackgroundColor, headerTextColor } = getStyle();
 
     const ownerHtml = Mustache.render(ownerTemplate, {
       folio: project.id,
@@ -346,7 +348,9 @@ router.get('/projects/:id/pdf', async (req, res) => {
       folioFiscal: '',
       selloSat: '',
       selloEmisor: '',
-      cadenaOriginal: ''
+      cadenaOriginal: '',
+      headerBackgroundColor,
+      headerTextColor
     });
 
     const clientHtml = Mustache.render(clientTemplate, {
@@ -366,7 +370,9 @@ router.get('/projects/:id/pdf', async (req, res) => {
       folioFiscal: '',
       selloSat: '',
       selloEmisor: '',
-      cadenaOriginal: ''
+      cadenaOriginal: '',
+      headerBackgroundColor,
+      headerTextColor
     });
 
     res.setHeader('Content-Type', 'application/pdf');

--- a/routes/remissionStyle.js
+++ b/routes/remissionStyle.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const { getStyle, saveStyle } = require('../Modules/styleConfig');
+const router = express.Router();
+
+/**
+ * @openapi
+ * /remission-style:
+ *   get:
+ *     summary: Obtener estilos de remisión
+ *     tags:
+ *       - RemissionStyle
+ *   put:
+ *     summary: Actualizar estilos de remisión
+ *     tags:
+ *       - RemissionStyle
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               headerBackgroundColor:
+ *                 type: string
+ *               headerTextColor:
+ *                 type: string
+ */
+
+// Obtener estilos actuales
+router.get('/remission-style', (req, res) => {
+  res.json(getStyle());
+});
+
+// Actualizar estilos de remisión
+router.put('/remission-style', (req, res) => {
+  const { headerBackgroundColor, headerTextColor } = req.body;
+  if (!headerBackgroundColor && !headerTextColor) {
+    return res.status(400).json({ message: 'Se requiere al menos un campo' });
+  }
+  const style = saveStyle({ headerBackgroundColor, headerTextColor });
+  res.json(style);
+});
+
+module.exports = router;

--- a/templates/remission.html
+++ b/templates/remission.html
@@ -11,7 +11,7 @@
     h2{font-size:14px;margin-top:12px}
     table{width:100%;border-collapse:collapse;margin-top:8px}
     th,td{border:1px solid #888;padding:4px;text-align:left;font-size:11px}
-    th{background:#f0f0f0;font-weight:600}
+    th{background:{{headerBackgroundColor}};color:{{headerTextColor}};font-weight:600}
     .right{text-align:right}
     .center{text-align:center}
     /* Allow long texts to wrap within the column */

--- a/templates/remission_client.html
+++ b/templates/remission_client.html
@@ -11,7 +11,7 @@
     h2{font-size:14px;margin-top:12px}
     table{width:100%;border-collapse:collapse;margin-top:8px}
     th,td{border:1px solid #888;padding:4px;text-align:left;font-size:11px}
-    th{background:#f0f0f0;font-weight:600}
+    th{background:{{headerBackgroundColor}};color:{{headerTextColor}};font-weight:600}
     .right{text-align:right}
     .center{text-align:center}
     /* Allow long texts to wrap within the column */

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -9,6 +9,7 @@ const clientsRouter = require('../routes/clients');
 const projectsRouter = require('../routes/projects');
 const installationCostsRouter = require('../routes/installationCosts');
 const ownerCompaniesRouter = require('../routes/ownerCompanies');
+const remissionStyleRouter = require('../routes/remissionStyle');
 
 describe('Route definitions', () => {
   it('materials router has routes configured', () => {
@@ -63,5 +64,9 @@ describe('Route definitions', () => {
 
   it('owner companies router has routes configured', () => {
     expect(ownerCompaniesRouter.stack).to.be.an('array').that.is.not.empty;
+  });
+
+  it('remission style router has routes configured', () => {
+    expect(remissionStyleRouter.stack).to.be.an('array').that.is.not.empty;
   });
 });


### PR DESCRIPTION
## Summary
- update all Postman collections with `Remission Style` folder containing new `GET` and `PUT` requests

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae6206f14832db1d25817a3cd5014