### PR TITLE
Add remissions by owner endpoint

### DIFF
--- a/API_NODE.postman_collection.json
+++ b/API_NODE.postman_collection.json
@@ -679,6 +679,37 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "Remissions",
+      "item": [
+        {
+          "name": "Get Remissions by Owner",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/remissions/by-owner/1",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "remissions",
+                "by-owner",
+                "1"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ]
 }

--- a/API_NODE_New.postman_collection.json
+++ b/API_NODE_New.postman_collection.json
@@ -1100,6 +1100,37 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "Remissions",
+      "item": [
+        {
+          "name": "Get Remissions by Owner",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/remissions/by-owner/1",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "remissions",
+                "by-owner",
+                "1"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -130,3 +130,11 @@ En el cuerpo envía los campos `headerBackgroundColor` y/o `headerTextColor` en 
 ```http
 GET /remission-style
 ```
+
+## Consultar remisiones por owner
+
+Para obtener todas las remisiones asociadas a un propietario utiliza:
+
+```http
+GET /remissions/by-owner/{owner_id}
+```

--- a/api.js
+++ b/api.js
@@ -25,6 +25,7 @@ const projectsRouter = require('./routes/projects');
 const installationCostsRouter = require('./routes/installationCosts');
 const ownerCompaniesRouter = require('./routes/ownerCompanies');
 const remissionStyleRouter = require('./routes/remissionStyle');
+const remissionsRouter = require('./routes/remissions');
 
 const app = express();
 app.use(passport.initialize());
@@ -94,6 +95,7 @@ app.use('/', authenticateJWT, projectsRouter);
 app.use('/', authenticateJWT, installationCostsRouter);
 app.use('/', authenticateJWT, ownerCompaniesRouter);
 app.use('/', authenticateJWT, remissionStyleRouter);
+app.use('/', authenticateJWT, remissionsRouter);
 
 // Middleware para manejar errores
 app.use((err, req, res, next) => {

--- a/models/remissionsModel.js
+++ b/models/remissionsModel.js
@@ -45,9 +45,20 @@ const findByProjectId = (projectId) => {
   });
 };
 
+const findByOwnerId = (ownerId) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'SELECT * FROM remissions WHERE owner_id = ?';
+    db.query(sql, [ownerId], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+};
+
 module.exports = {
   createRemission,
   findById,
   findAll,
-  findByProjectId
+  findByProjectId,
+  findByOwnerId
 };

--- a/routes/remissions.js
+++ b/routes/remissions.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const Remissions = require('../models/remissionsModel');
+const router = express.Router();
+
+/**
+ * @openapi
+ * /remissions/by-owner/{owner_id}:
+ *   get:
+ *     summary: Obtener remisiones por owner
+ *     tags:
+ *       - Remissions
+ *     parameters:
+ *       - in: path
+ *         name: owner_id
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Lista de remisiones
+ */
+router.get('/remissions/by-owner/:owner_id', async (req, res) => {
+  try {
+    const remissions = await Remissions.findByOwnerId(req.params.owner_id);
+    res.json(remissions);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add `findByOwnerId` model method
- create route to get remissions by owner
- expose remissions router in API
- document the new route in README
- update Postman collections with new request

## Testing
- `npm install` *(fails: 403 Forbidden for html-pdf)*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684afb768fb0832dbe2b00754c54e027