### PR TITLE
Allow multiple CORS origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 PORT=3000
 JWT_SECRET=keySecret
 OPERACIONES_SECRET=4RC542024L3v4n74m13n70
-CORS_ORIGIN=http://localhost:3000
+CORS_ORIGIN=http://localhost:4200
 
 DB_HOST=localhost
 DB_USER=user

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ siguientes variables:
 PORT=3000
 JWT_SECRET=keySecret
 OPERACIONES_SECRET=4RC542024L3v4n74m13n70
-CORS_ORIGIN=http://localhost:3000
+CORS_ORIGIN=http://localhost:4200
 DB_HOST=localhost
 DB_USER=user
 DB_PASSWORD=password
@@ -81,8 +81,10 @@ probar estas solicitudes y construir un playset completo.
 
 ## Configuración de CORS
 
-El dominio permitido se define con la variable de entorno `CORS_ORIGIN`. Si no se
-especifica se permite cualquier origen.
+El dominio permitido se define con la variable de entorno `CORS_ORIGIN`. Puedes
+proporcionar varios orígenes separados por comas. De forma predeterminada la
+aplicación siempre permitirá `http://localhost:4200` para facilitar el trabajo
+en local. Si no se especifica la variable, se permite cualquier origen.
 
 ## Pruebas
 

--- a/api.js
+++ b/api.js
@@ -29,8 +29,17 @@ const remissionsRouter = require('./routes/remissions');
 
 const app = express();
 app.use(passport.initialize());
+let allowedOrigins;
+if (process.env.CORS_ORIGIN) {
+    allowedOrigins = process.env.CORS_ORIGIN.split(',').map(o => o.trim());
+    if (!allowedOrigins.includes('http://localhost:4200')) {
+        allowedOrigins.push('http://localhost:4200');
+    }
+} else {
+    allowedOrigins = '*';
+}
 app.use(cors({
-    origin: process.env.CORS_ORIGIN || '*',
+    origin: allowedOrigins,
     methods: ['GET', 'POST', 'PUT', 'DELETE'],
     allowedHeaders: ['Content-Type', 'Authorization']
 }));


### PR DESCRIPTION
## Summary
- update CORS middleware to support multiple origins
- document localhost:4200 as the default dev origin
- note comma separated origins in README
- update example .env file

## Testing
- `./run-tests.sh` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html-pdf)*

------
https://chatgpt.com/codex/tasks/task_e_684b139f3f4c832d89869b66d26d6d61