### PR TITLE
Fix logout endpoint to verify token

### DIFF
--- a/API_NODE.postman_collection.json
+++ b/API_NODE.postman_collection.json
@@ -105,10 +105,8 @@
         "method": "POST",
         "header": [
           {
-            "key": "",
-            "value": "",
-            "type": "text",
-            "disabled": true
+            "key": "Authorization",
+            "value": "Bearer {{token}}"
           }
         ],
         "body": {

--- a/API_NODE_New.postman_collection.json
+++ b/API_NODE_New.postman_collection.json
@@ -34,6 +34,31 @@
       "response": []
     },
     {
+      "name": "Logout",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Authorization",
+            "value": "Bearer {{token}}"
+          }
+        ],
+        "url": {
+          "raw": "http://localhost:3000/auth/logout",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "auth",
+            "logout"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
       "name": "Materials",
       "item": [
         {

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -70,9 +70,18 @@ const jwtSecret = process.env.JWT_SECRET;
  *     summary: Cerrar sesión
  *     tags:
  *       - Auth
+ *     parameters:
+ *       - in: header
+ *         name: Authorization
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Token JWT con el prefijo Bearer
  *     responses:
  *       200:
  *         description: Logout exitoso
+ *       401:
+ *         description: No hay sesión activa
  */
 
 // Ruta de registro de usuarios
@@ -132,9 +141,22 @@ router.post('/login', async (req, res, next) => {
  * @route POST /logout
  */
 router.post('/logout', (req, res) => {
-    if (!req.cookies.jwt) {
+    const cookieToken = req.cookies.jwt;
+    const headerToken = req.headers.authorization;
+
+    if (!cookieToken) {
         return res.status(401).json({ message: 'No hay sesión activa' });
     }
+
+    if (!headerToken || !headerToken.startsWith('Bearer ')) {
+        return res.status(401).json({ message: 'Token no proporcionado' });
+    }
+
+    const token = headerToken.split(' ')[1];
+    if (token !== cookieToken) {
+        return res.status(401).json({ message: 'Tokens JWT no coinciden' });
+    }
+
     res.clearCookie('jwt');
     res.status(200).json({ message: 'Logout exitoso' });
 });


### PR DESCRIPTION
## Summary
- verify Authorization header in logout endpoint
- document Authorization header for /auth/logout in Swagger
- add logout request to Postman collections

## Testing
- `npm install` *(fails: 403 Forbidden - html-pdf)*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1a62f5e0832d8be8358ad3124319