### PR TITLE
Add menus model and endpoints

### DIFF
--- a/API_NODE_New.postman_collection.json
+++ b/API_NODE_New.postman_collection.json
@@ -1156,6 +1156,68 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "Menus",
+      "item": [
+        {
+          "name": "Create Menu",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"name\": \"Menu name\",\n  \"path\": null,\n  \"parent_id\": null\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "http://localhost:3000/menus",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "menus"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Get Menus",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/menus",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "menus"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ]
 }

--- a/api.js
+++ b/api.js
@@ -26,6 +26,7 @@ const installationCostsRouter = require('./routes/installationCosts');
 const ownerCompaniesRouter = require('./routes/ownerCompanies');
 const remissionStyleRouter = require('./routes/remissionStyle');
 const remissionsRouter = require('./routes/remissions');
+const menusRouter = require('./routes/menus');
 
 const app = express();
 app.use(passport.initialize());
@@ -105,6 +106,7 @@ app.use('/', authenticateJWT, installationCostsRouter);
 app.use('/', authenticateJWT, ownerCompaniesRouter);
 app.use('/', authenticateJWT, remissionStyleRouter);
 app.use('/', authenticateJWT, remissionsRouter);
+app.use('/', authenticateJWT, menusRouter);
 
 // Middleware para manejar errores
 app.use((err, req, res, next) => {

--- a/models/menusModel.js
+++ b/models/menusModel.js
@@ -1,0 +1,48 @@
+const db = require('../db');
+
+/**
+ * Crea un nuevo menú o submenú.
+ * @param {string} name - Nombre a mostrar.
+ * @param {string|null} path - Ruta del enlace o null si es contenedor.
+ * @param {number|null} parentId - ID del menú padre o null para nivel raíz.
+ * @returns {Promise<object>} Menú creado.
+ */
+const createMenu = (name, path = null, parentId = null, ownerId = 1) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'INSERT INTO menus (name, path, parent_id, owner_id) VALUES (?, ?, ?, ?)';
+    db.query(sql, [name, path, parentId, ownerId], (err, result) => {
+      if (err) return reject(err);
+      resolve({ id: result.insertId, name, path, parent_id: parentId, owner_id: ownerId });
+    });
+  });
+};
+
+/**
+ * Obtiene el árbol completo de menús con submenús.
+ * @returns {Promise<object[]>} Árbol de menús.
+ */
+const getMenuTree = () => {
+  return new Promise((resolve, reject) => {
+    const sql = 'SELECT id, name, path, parent_id FROM menus ORDER BY id';
+    db.query(sql, (err, rows) => {
+      if (err) return reject(err);
+      const map = {};
+      rows.forEach((row) => {
+        map[row.id] = { ...row, children: [] };
+      });
+      const tree = [];
+      rows.forEach((row) => {
+        if (row.parent_id) {
+          if (map[row.parent_id]) {
+            map[row.parent_id].children.push(map[row.id]);
+          }
+        } else {
+          tree.push(map[row.id]);
+        }
+      });
+      resolve(tree);
+    });
+  });
+};
+
+module.exports = { createMenu, getMenuTree };

--- a/routes/menus.js
+++ b/routes/menus.js
@@ -1,0 +1,56 @@
+const express = require('express');
+const Menus = require('../models/menusModel');
+const router = express.Router();
+
+/**
+ * @openapi
+ * /menus:
+ *   get:
+ *     summary: Obtener árbol de menús
+ *     tags:
+ *       - Menus
+ *     responses:
+ *       200:
+ *         description: Árbol de menús
+ *   post:
+ *     summary: Crear menú o submenú
+ *     tags:
+ *       - Menus
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *               path:
+ *                 type: string
+ *               parent_id:
+ *                 type: integer
+ *                 nullable: true
+ *     responses:
+ *       201:
+ *         description: Menú creado
+ */
+router.get('/menus', async (req, res) => {
+  try {
+    const menus = await Menus.getMenuTree();
+    res.json(menus);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+router.post('/menus', async (req, res) => {
+  try {
+    const { name, path = null, parent_id = null } = req.body;
+    const menu = await Menus.createMenu(name, path, parent_id, 1);
+    res.status(201).json(menu);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+module.exports = router;

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -7,6 +7,7 @@ const clients = require('../models/clientsModel');
 const projects = require('../models/projectsModel');
 const installationCosts = require('../models/installationCostsModel');
 const ownerCompanies = require('../models/ownerCompaniesModel');
+const menus = require('../models/menusModel');
 
 describe('Model exports', () => {
   it('materials model exposes CRUD functions', () => {
@@ -50,6 +51,11 @@ describe('Model exports', () => {
 
   it('ownerCompanies model exposes update logo function', () => {
     expect(ownerCompanies.updateLogoPath).to.be.a('function');
+  });
+
+  it('menus model exposes CRUD functions', () => {
+    expect(menus.createMenu).to.be.a('function');
+    expect(menus.getMenuTree).to.be.a('function');
   });
 });
 


### PR DESCRIPTION
## Summary
- add database model for hierarchical menus
- expose routes to create menus and fetch menu tree
- register routes in the main app
- add tests for new model exports
- update Postman collection with menu requests

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html-pdf)*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1f498e28832db2615f35c5bd8a09