### PR TITLE
Document owner-specific menus endpoint

### DIFF
--- a/API_NODE_New.postman_collection.json
+++ b/API_NODE_New.postman_collection.json
@@ -1210,7 +1210,7 @@
               }
             ],
             "url": {
-              "raw": "http://localhost:3000/menus",
+              "raw": "http://localhost:3000/menus?owner_id=1",
               "protocol": "http",
               "host": [
                 "localhost"
@@ -1218,6 +1218,12 @@
               "port": "3000",
               "path": [
                 "menus"
+              ],
+              "query": [
+                {
+                  "key": "owner_id",
+                  "value": "1"
+                }
               ]
             }
           },

--- a/README.md
+++ b/README.md
@@ -140,3 +140,30 @@ Para obtener todas las remisiones asociadas a un propietario utiliza:
 ```http
 GET /remissions/by-owner/{owner_id}
 ```
+
+## Menús por propietario
+
+El endpoint `GET /menus` permite filtrar los menús pertenecientes a una empresa
+(**owner**) utilizando el parámetro de consulta `owner_id`. Si no se indica, se
+asume el valor `1`.
+
+```http
+GET /menus?owner_id=<id>
+```
+
+Para crear un menú asociado a un propietario también se puede enviar el campo
+`owner_id` en el cuerpo de la petición:
+
+```http
+POST /menus
+Content-Type: application/json
+
+{
+  "name": "Nombre del menú",
+  "path": null,
+  "parent_id": null,
+  "owner_id": <id>
+}
+```
+
+De esta manera cada empresa puede contar con su propio conjunto de menús.

--- a/routes/menus.js
+++ b/routes/menus.js
@@ -15,7 +15,8 @@ const router = express.Router();
  *         schema:
  *           type: integer
  *         required: false
- *         description: ID del owner para filtrar
+ *         description: ID del owner para filtrar (por defecto 1)
+ *         example: 1
  *     responses:
  *       200:
  *         description: Árbol de menús
@@ -41,6 +42,8 @@ const router = express.Router();
  *               owner_id:
  *                 type: integer
  *                 nullable: true
+ *                 description: ID del owner (por defecto 1)
+ *                 example: 1
  *     responses:
  *       201:
  *         description: Menú creado


### PR DESCRIPTION
## Summary
- document how to filter or create menus for a specific owner using `owner_id`
- update Postman collection with `owner_id` query parameter
- note default owner in Swagger docs

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b22adeb58832db0d9e4ca5034540f