### PR TITLE
Add all menus listing endpoint

### DIFF
--- a/API_NODE_New.postman_collection.json
+++ b/API_NODE_New.postman_collection.json
@@ -1228,6 +1228,37 @@
             }
           },
           "response": []
+        },
+        {
+          "name": "List All Menus",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/menus/all?owner_id=1",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "menus",
+                "all"
+              ],
+              "query": [
+                {
+                  "key": "owner_id",
+                  "value": "1"
+                }
+              ]
+            }
+          },
+          "response": []
         }
       ]
     }

--- a/models/menusModel.js
+++ b/models/menusModel.js
@@ -45,4 +45,19 @@ const getMenuTree = (ownerId = 1) => {
   });
 };
 
-module.exports = { createMenu, getMenuTree };
+/**
+ * Obtiene todos los menús registrados para un owner.
+ * @param {number} ownerId - ID del owner.
+ * @returns {Promise<object[]>} Listado de menús.
+ */
+const findAll = (ownerId = 1) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'SELECT * FROM menus WHERE owner_id = ? ORDER BY id';
+    db.query(sql, [ownerId], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+};
+
+module.exports = { createMenu, getMenuTree, findAll };

--- a/routes/menus.js
+++ b/routes/menus.js
@@ -58,6 +58,35 @@ router.get('/menus', async (req, res) => {
   }
 });
 
+/**
+ * @openapi
+ * /menus/all:
+ *   get:
+ *     summary: Listar todos los menús
+ *     tags:
+ *       - Menus
+ *     parameters:
+ *       - in: query
+ *         name: owner_id
+ *         schema:
+ *           type: integer
+ *         required: false
+ *         description: ID del owner para filtrar (por defecto 1)
+ *         example: 1
+ *     responses:
+ *       200:
+ *         description: Lista de menús
+ */
+router.get('/menus/all', async (req, res) => {
+  try {
+    const ownerId = parseInt(req.query.owner_id || '1', 10);
+    const menus = await Menus.findAll(ownerId);
+    res.json(menus);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
 router.post('/menus', async (req, res) => {
   try {
     const { name, path = null, parent_id = null, owner_id = 1 } = req.body;


### PR DESCRIPTION
## Summary
- add `findAll` function to the menus model
- provide `/menus/all` route to list every menu
- document new endpoint in Swagger comments
- extend Postman collection with request for `/menus/all`

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b29bb2a7c832d8f706e974261a4ad