### PR TITLE
Enable cookie auth across CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ probar estas solicitudes y construir un playset completo.
 El dominio permitido se define con la variable de entorno `CORS_ORIGIN`. Puedes
 proporcionar varios orígenes separados por comas. De forma predeterminada la
 aplicación siempre permitirá `http://localhost:4200` para facilitar el trabajo
-en local. Si no se especifica la variable, se permite cualquier origen.
+en local. Si no se especifica la variable, se permite cualquier origen. La
+configuración incluye `credentials: true` para permitir el envío de cookies en
+solicitudes cross-origin, por lo que asegúrate de definir `CORS_ORIGIN` cuando
+uses autenticación basada en cookies.
 
 ## Pruebas
 

--- a/api.js
+++ b/api.js
@@ -42,7 +42,8 @@ if (process.env.CORS_ORIGIN) {
 app.use(cors({
     origin: allowedOrigins,
     methods: ['GET', 'POST', 'PUT', 'DELETE'],
-    allowedHeaders: ['Content-Type', 'Authorization']
+    allowedHeaders: ['Content-Type', 'Authorization'],
+    credentials: true
 }));
 const port = process.env.PORT || 3000;
 


### PR DESCRIPTION
## Summary
- allow CORS credentials in `api.js`
- mention credentials behaviour in README

## Testing
- `npm test` *(fails: mocha not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b2f7bc480832d8f233a823a17eaf3