### PR TITLE
Improve CORS handling when CORS_ORIGIN is unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ configuración incluye `credentials: true` para permitir el envío de cookies en
 solicitudes cross-origin, por lo que asegúrate de definir `CORS_ORIGIN` cuando
 uses autenticación basada en cookies.
 
+Cuando consumas los endpoints protegidos desde Angular, incluye el token JWT en
+el encabezado `Authorization` y establece `withCredentials: true` para que el
+navegador envíe la cookie con el token.
+
 ## Pruebas
 
 Para asegurarte de que las dependencias de desarrollo necesarias para las

--- a/api.js
+++ b/api.js
@@ -30,21 +30,35 @@ const menusRouter = require('./routes/menus');
 
 const app = express();
 app.use(passport.initialize());
-let allowedOrigins;
+
+let corsOptions;
 if (process.env.CORS_ORIGIN) {
-    allowedOrigins = process.env.CORS_ORIGIN.split(',').map(o => o.trim());
+    const allowedOrigins = process.env.CORS_ORIGIN.split(',').map(o => o.trim());
     if (!allowedOrigins.includes('http://localhost:4200')) {
         allowedOrigins.push('http://localhost:4200');
     }
+    corsOptions = {
+        origin: (origin, callback) => {
+            if (!origin) return callback(null, true);
+            if (allowedOrigins.includes(origin)) {
+                return callback(null, true);
+            }
+            return callback(new Error('Not allowed by CORS'));
+        },
+        methods: ['GET', 'POST', 'PUT', 'DELETE'],
+        allowedHeaders: ['Content-Type', 'Authorization'],
+        credentials: true
+    };
 } else {
-    allowedOrigins = '*';
+    corsOptions = {
+        origin: true, // reflect origin header
+        methods: ['GET', 'POST', 'PUT', 'DELETE'],
+        allowedHeaders: ['Content-Type', 'Authorization'],
+        credentials: true
+    };
 }
-app.use(cors({
-    origin: allowedOrigins,
-    methods: ['GET', 'POST', 'PUT', 'DELETE'],
-    allowedHeaders: ['Content-Type', 'Authorization'],
-    credentials: true
-}));
+
+app.use(cors(corsOptions));
 const port = process.env.PORT || 3000;
 
 app.use(cookieParser());


### PR DESCRIPTION
## Summary
- avoid using `*` with credentials in CORS setup
- echo request origin if `CORS_ORIGIN` is not configured
- document using `withCredentials` and `Authorization` header from Angular

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b31adc438832d87eb2a0fcc983e91