### PR TITLE
Fix CORS for custom token header

### DIFF
--- a/api.js
+++ b/api.js
@@ -46,14 +46,14 @@ if (process.env.CORS_ORIGIN) {
             return callback(new Error('Not allowed by CORS'));
         },
         methods: ['GET', 'POST', 'PUT', 'DELETE'],
-        allowedHeaders: ['Content-Type', 'Authorization'],
+        allowedHeaders: ['Content-Type', 'Authorization', 'token'],
         credentials: true
     };
 } else {
     corsOptions = {
         origin: true, // reflect origin header
         methods: ['GET', 'POST', 'PUT', 'DELETE'],
-        allowedHeaders: ['Content-Type', 'Authorization'],
+        allowedHeaders: ['Content-Type', 'Authorization', 'token'],
         credentials: true
     };
 }


### PR DESCRIPTION
## Summary
- allow `token` header in Express CORS configuration

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b33dbc090832db146e495b0224b35