### PR TITLE
Fix JWT middleware to accept header or cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ configuración incluye `credentials: true` para permitir el envío de cookies en
 solicitudes cross-origin, por lo que asegúrate de definir `CORS_ORIGIN` cuando
 uses autenticación basada en cookies.
 
-Cuando consumas los endpoints protegidos desde Angular, incluye el token JWT en
-el encabezado `Authorization` y establece `withCredentials: true` para que el
-navegador envíe la cookie con el token.
+Al consumir los endpoints protegidos debes enviar el token JWT. Puedes
+hacerlo en el encabezado `Authorization` (recomendado) o confiar en la cookie
+`jwt`. Si utilizas cookies, establece `withCredentials: true` para que el
+navegador la envíe en cada solicitud.
 
 ## Pruebas
 

--- a/api.js
+++ b/api.js
@@ -87,23 +87,25 @@ app.use('/operaciones', operaciones);
 // Middleware para la autenticacion de passport
 const authenticateJWT = (req, res, next) => {
     const cookieToken = req.cookies.jwt;
-    const headerToken = req.headers.authorization;
-    if (!cookieToken) {
-        return res.status(401).json({ message: 'Token no proporcionado en la cookie' });
+    const headerToken = req.headers.authorization && req.headers.authorization.startsWith('Bearer ')
+        ? req.headers.authorization.split(' ')[1]
+        : null;
+
+    const token = headerToken || cookieToken;
+
+    if (!token) {
+        return res.status(401).json({ message: 'Token no proporcionado' });
     }
-    if (!headerToken || !headerToken.startsWith('Bearer ')) {
-        return res.status(401).json({ message: 'Token no proporcionado en los headers de la solicitud' });
-    }
-    const token = headerToken.split(' ')[1];
-    if (token !== cookieToken) {
+
+    if (headerToken && cookieToken && headerToken !== cookieToken) {
         return res.status(401).json({ message: 'Tokens JWT no coinciden' });
     }
-    jwt.verify(token, process.env.JWT_SECRET, (err, decodedToken) => {
+
+    jwt.verify(token, process.env.JWT_SECRET, (err) => {
         if (err) {
             return res.status(401).json({ message: 'Token inválido' });
-        } else {
-            next();
         }
+        next();
     });
 };
 

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -142,18 +142,15 @@ router.post('/login', async (req, res, next) => {
  */
 router.post('/logout', (req, res) => {
     const cookieToken = req.cookies.jwt;
-    const headerToken = req.headers.authorization;
+    const headerToken = req.headers.authorization && req.headers.authorization.startsWith('Bearer ')
+        ? req.headers.authorization.split(' ')[1]
+        : null;
 
-    if (!cookieToken) {
+    if (!cookieToken && !headerToken) {
         return res.status(401).json({ message: 'No hay sesión activa' });
     }
 
-    if (!headerToken || !headerToken.startsWith('Bearer ')) {
-        return res.status(401).json({ message: 'Token no proporcionado' });
-    }
-
-    const token = headerToken.split(' ')[1];
-    if (token !== cookieToken) {
+    if (cookieToken && headerToken && cookieToken !== headerToken) {
         return res.status(401).json({ message: 'Tokens JWT no coinciden' });
     }
 


### PR DESCRIPTION
## Summary
- relax JWT middleware so header or cookie token can be used
- adjust logout route to accept either token source
- clarify README to explain token usage

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b35b80eec832dbf4e315c8a48cbfb