### PR TITLE
Add pagination to materials endpoint

### DIFF
--- a/API_NODE_New.postman_collection.json
+++ b/API_NODE_New.postman_collection.json
@@ -72,7 +72,7 @@
               }
             ],
             "url": {
-              "raw": "http://localhost:3000/materials",
+              "raw": "http://localhost:3000/materials?page=1&limit=10",
               "protocol": "http",
               "host": [
                 "localhost"
@@ -80,6 +80,16 @@
               "port": "3000",
               "path": [
                 "materials"
+              ],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "limit",
+                  "value": "10"
+                }
               ]
             }
           },

--- a/models/materialsModel.js
+++ b/models/materialsModel.js
@@ -73,6 +73,27 @@ const findAll = () => {
 };
 
 /**
+ * Obtiene materiales con paginación.
+ * @param {number} page - Número de página.
+ * @param {number} limit - Cantidad de registros por página.
+ * @returns {Promise<object[]>} Listado de materiales paginado.
+ * @throws {Error} Si ocurre un error al consultar la base de datos.
+ */
+const findPaginated = (page = 1, limit = 10) => {
+  const offset = (page - 1) * limit;
+  return new Promise((resolve, reject) => {
+    db.query(
+      'SELECT * FROM raw_materials LIMIT ? OFFSET ?',
+      [parseInt(limit, 10), offset],
+      (err, rows) => {
+        if (err) return reject(err);
+        resolve(rows);
+      }
+    );
+  });
+};
+
+/**
  * Actualiza los datos de un material.
  * @param {number} id - ID del material.
  * @param {string} name - Nombre del material.
@@ -126,6 +147,7 @@ module.exports = {
   createMaterial,
   findById,
   findAll,
+  findPaginated,
   updateMaterial,
   deleteMaterial
 };

--- a/routes/materials.js
+++ b/routes/materials.js
@@ -9,6 +9,21 @@ const router = express.Router();
  *     summary: Listar materiales
  *     tags:
  *       - Materials
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *         required: false
+ *         description: Número de página (por defecto 1)
+ *         example: 1
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *         required: false
+ *         description: Cantidad de elementos por página (por defecto 10)
+ *         example: 10
  *     responses:
  *       200:
  *         description: Lista de materiales
@@ -94,7 +109,9 @@ const router = express.Router();
  */
 router.get('/materials', async (req, res) => {
   try {
-    const materials = await Materials.findAll();
+    const page = parseInt(req.query.page || '1', 10);
+    const limit = parseInt(req.query.limit || '10', 10);
+    const materials = await Materials.findPaginated(page, limit);
     res.json(materials);
   } catch (error) {
     res.status(500).json({ message: error.message });


### PR DESCRIPTION
## Summary
- support pagination in materials GET route
- document pagination params in swagger comments
- expose new `findPaginated` model method
- update Postman collection with pagination query

## Testing
- `./run-tests.sh` *(fails: 403 Forbidden when downloading npm packages)*

------
https://chatgpt.com/codex/tasks/task_e_684bad7f5f6c832d923f1afcf66ae86c