### PR TITLE
Add pagination metadata to materials list

### DIFF
--- a/models/materialsModel.js
+++ b/models/materialsModel.js
@@ -94,6 +94,20 @@ const findPaginated = (page = 1, limit = 10) => {
 };
 
 /**
+ * Cuenta el total de materiales registrados.
+ * @returns {Promise<number>} Cantidad de materiales.
+ * @throws {Error} Si ocurre un error al consultar la base de datos.
+ */
+const countAll = () => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT COUNT(*) AS count FROM raw_materials', (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows[0].count);
+    });
+  });
+};
+
+/**
  * Actualiza los datos de un material.
  * @param {number} id - ID del material.
  * @param {string} name - Nombre del material.
@@ -148,6 +162,7 @@ module.exports = {
   findById,
   findAll,
   findPaginated,
+  countAll,
   updateMaterial,
   deleteMaterial
 };

--- a/routes/materials.js
+++ b/routes/materials.js
@@ -27,6 +27,23 @@ const router = express.Router();
  *     responses:
  *       200:
  *         description: Lista de materiales
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 docs:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                 totalDocs:
+ *                   type: integer
+ *                 totalPages:
+ *                   type: integer
+ *                 page:
+ *                   type: integer
+ *                 limit:
+ *                   type: integer
  *   post:
  *     summary: Crear material
  *     tags:
@@ -111,8 +128,20 @@ router.get('/materials', async (req, res) => {
   try {
     const page = parseInt(req.query.page || '1', 10);
     const limit = parseInt(req.query.limit || '10', 10);
-    const materials = await Materials.findPaginated(page, limit);
-    res.json(materials);
+    const [materials, totalDocs] = await Promise.all([
+      Materials.findPaginated(page, limit),
+      Materials.countAll()
+    ]);
+
+    const totalPages = Math.ceil(totalDocs / limit);
+
+    res.json({
+      docs: materials,
+      totalDocs,
+      totalPages,
+      page,
+      limit
+    });
   } catch (error) {
     res.status(500).json({ message: error.message });
   }


### PR DESCRIPTION
## Summary
- include total count helper in materials model
- expose pagination data in materials route
- document new response fields in swagger comments

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc443b054832dbe8108184c4136d6