### PR TITLE
Add search parameter for materials listing

### DIFF
--- a/API_NODE_New.postman_collection.json
+++ b/API_NODE_New.postman_collection.json
@@ -72,7 +72,7 @@
               }
             ],
             "url": {
-              "raw": "http://localhost:3000/materials?page=1&limit=10",
+              "raw": "http://localhost:3000/materials?page=1&limit=10&search=madera",
               "protocol": "http",
               "host": [
                 "localhost"
@@ -89,6 +89,10 @@
                 {
                   "key": "limit",
                   "value": "10"
+                },
+                {
+                  "key": "search",
+                  "value": "madera"
                 }
               ]
             }

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ DB_NAME=demodb
 - `POST /operaciones/suma-numeros` Retorna la suma de dos números y almacena el resultado en MySQL.
 - `GET /public-apis/get-api` Consume una API pública.
 - `GET /materials` Lista materiales (protegido).
+  - Parámetros opcionales: `page`, `limit` y `search` para paginar y filtrar por texto.
 - `GET /accessories` Lista accesorios (protegido).
 - `GET /playsets` Lista playsets (protegido).
 - `GET /playsets/:id/cost` Calcula el costo total de un playset.

--- a/routes/materials.js
+++ b/routes/materials.js
@@ -24,6 +24,13 @@ const router = express.Router();
  *         required: false
  *         description: Cantidad de elementos por página (por defecto 10)
  *         example: 10
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         required: false
+ *         description: Texto a buscar en cualquier campo
+ *         example: madera
  *     responses:
  *       200:
  *         description: Lista de materiales
@@ -128,9 +135,10 @@ router.get('/materials', async (req, res) => {
   try {
     const page = parseInt(req.query.page || '1', 10);
     const limit = parseInt(req.query.limit || '10', 10);
+    const search = req.query.search || '';
     const [materials, totalDocs] = await Promise.all([
-      Materials.findPaginated(page, limit),
-      Materials.countAll()
+      Materials.findPaginated(page, limit, search),
+      Materials.countAll(search)
     ]);
 
     const totalPages = Math.ceil(totalDocs / limit);
@@ -140,7 +148,8 @@ router.get('/materials', async (req, res) => {
       totalDocs,
       totalPages,
       page,
-      limit
+      limit,
+      search
     });
   } catch (error) {
     res.status(500).json({ message: error.message });

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -14,6 +14,7 @@ describe('Model exports', () => {
     expect(materials.createMaterial).to.be.a('function');
     expect(materials.findById).to.be.a('function');
     expect(materials.findAll).to.be.a('function');
+    expect(materials.findPaginated).to.be.a('function');
   });
 
   it('accessories model exposes CRUD functions', () => {
@@ -97,6 +98,21 @@ describe('Model logic', () => {
       price: 20,
       owner_id: 1
     });
+  });
+
+  it('findPaginated builds search query when term provided', async () => {
+    let capturedSql = '';
+    let capturedParams = [];
+    db.query = (sql, params, callback) => {
+      capturedSql = sql;
+      capturedParams = params;
+      callback(null, []);
+    };
+
+    await materials.findPaginated(1, 5, 'wood');
+
+    expect(capturedSql).to.contain('LIKE');
+    expect(capturedParams[0]).to.equal('%wood%');
   });
 
   it('calculateCost computes correct cost based on material dimensions', async () => {


### PR DESCRIPTION
## Summary
- support text search for materials using optional `search` query
- document search parameter in swagger and README
- test search query builder
- update Postman collection with search example

## Testing
- `npm test` *(fails: mocha not found)*
- `./run-tests.sh` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html-pdf)*

------
https://chatgpt.com/codex/tasks/task_e_684bc5d3e800832d9010dab5bfde6e43