### PR TITLE
Serve remission PDFs via static route

### DIFF
--- a/api.js
+++ b/api.js
@@ -67,6 +67,8 @@ app.use(bodyParser.json());
 
 // Serve uploaded files so templates can access logos
 app.use('/uploads', express.static('uploads'));
+// Serve generated remission PDFs
+app.use('/remissions', express.static('remissions'));
 
 // Documentación Swagger
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));

--- a/routes/remissions.js
+++ b/routes/remissions.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const path = require('path');
 const Remissions = require('../models/remissionsModel');
 const router = express.Router();
 
@@ -21,7 +22,12 @@ const router = express.Router();
 router.get('/remissions/by-owner/:owner_id', async (req, res) => {
   try {
     const remissions = await Remissions.findByOwnerIdWithClient(req.params.owner_id);
-    res.json(remissions);
+    const host = `${req.protocol}://${req.get('host')}`;
+    const formatted = remissions.map(r => ({
+      ...r,
+      pdf_path: r.pdf_path ? `${host}/remissions/${path.basename(r.pdf_path)}` : null
+    }));
+    res.json(formatted);
   } catch (error) {
     res.status(500).json({ message: error.message });
   }


### PR DESCRIPTION
## Summary
- expose `remissions` directory as static files
- return an accessible PDF URL in `/remissions/by-owner/:owner_id`

## Testing
- `./run-tests.sh` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_6859dfa2ec0c832db20653b88ec32ec8