### PR TITLE
Add pagination to remissions by owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Para obtener todas las remisiones asociadas a un propietario utiliza:
 ```http
 GET /remissions/by-owner/{owner_id}
 ```
+Puedes añadir los parámetros de consulta `page`, `limit` y `search` para
+paginar y filtrar los resultados.
 
 ## Menús por propietario
 

--- a/models/remissionsModel.js
+++ b/models/remissionsModel.js
@@ -91,11 +91,81 @@ const findByOwnerIdWithClient = (ownerId) => {
   });
 };
 
+const buildSearchQuery = (search) => {
+  if (!search) return { clause: '', params: [] };
+  const pattern = `%${search}%`;
+  const clause =
+    'AND CONCAT_WS(" ", r.id, r.project_id, r.data, r.pdf_path, r.recipient_type, r.owner_id, r.created_at, c.contact_name, c.company_name, c.address, c.requires_invoice, c.billing_info) LIKE ?';
+  return { clause, params: [pattern] };
+};
+
+const findByOwnerIdWithClientPaginated = (
+  ownerId,
+  page = 1,
+  limit = 10,
+  search = ''
+) => {
+  const offset = (page - 1) * limit;
+  return new Promise((resolve, reject) => {
+    const { clause, params } = buildSearchQuery(search);
+    const sql = `
+      SELECT r.*, c.id AS client_id, c.contact_name, c.company_name, c.address,
+             c.requires_invoice, c.billing_info
+      FROM remissions r
+      JOIN projects p ON r.project_id = p.id
+      JOIN clients c ON p.client_id = c.id
+      WHERE r.owner_id = ? ${clause}
+      LIMIT ? OFFSET ?`;
+    db.query(sql, [ownerId, ...params, parseInt(limit, 10), offset], (err, rows) => {
+      if (err) return reject(err);
+      const result = rows.map(row => {
+        const data = row.data ? JSON.parse(row.data) : null;
+        return {
+          id: row.id,
+          project_id: row.project_id,
+          data,
+          pdf_path: row.pdf_path,
+          recipient_type: row.recipient_type,
+          owner_id: row.owner_id,
+          created_at: row.created_at,
+          client: {
+            id: row.client_id,
+            contact_name: row.contact_name,
+            company_name: row.company_name,
+            address: row.address,
+            requires_invoice: row.requires_invoice,
+            billing_info: row.billing_info
+          }
+        };
+      });
+      resolve(result);
+    });
+  });
+};
+
+const countByOwnerIdWithClient = (ownerId, search = '') => {
+  return new Promise((resolve, reject) => {
+    const { clause, params } = buildSearchQuery(search);
+    const sql = `
+      SELECT COUNT(*) AS count
+      FROM remissions r
+      JOIN projects p ON r.project_id = p.id
+      JOIN clients c ON p.client_id = c.id
+      WHERE r.owner_id = ? ${clause}`;
+    db.query(sql, [ownerId, ...params], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows[0].count);
+    });
+  });
+};
+
 module.exports = {
   createRemission,
   findById,
   findAll,
   findByProjectId,
   findByOwnerId,
-  findByOwnerIdWithClient
+  findByOwnerIdWithClient,
+  findByOwnerIdWithClientPaginated,
+  countByOwnerIdWithClient
 };

--- a/routes/remissions.js
+++ b/routes/remissions.js
@@ -21,13 +21,27 @@ const router = express.Router();
  */
 router.get('/remissions/by-owner/:owner_id', async (req, res) => {
   try {
-    const remissions = await Remissions.findByOwnerIdWithClient(req.params.owner_id);
+    const page = parseInt(req.query.page || '1', 10);
+    const limit = parseInt(req.query.limit || '10', 10);
+    const search = req.query.search || '';
+    const [remissions, totalDocs] = await Promise.all([
+      Remissions.findByOwnerIdWithClientPaginated(req.params.owner_id, page, limit, search),
+      Remissions.countByOwnerIdWithClient(req.params.owner_id, search)
+    ]);
+    const totalPages = Math.ceil(totalDocs / limit);
     const host = `${req.protocol}://${req.get('host')}`;
     const formatted = remissions.map(r => ({
       ...r,
       pdf_path: r.pdf_path ? `${host}/remissions/${path.basename(r.pdf_path)}` : null
     }));
-    res.json(formatted);
+    res.json({
+      docs: formatted,
+      totalDocs,
+      totalPages,
+      page,
+      limit,
+      search
+    });
   } catch (error) {
     res.status(500).json({ message: error.message });
   }


### PR DESCRIPTION
## Summary
- support pagination for `/remissions/by-owner/:owner_id`
- implement `findByOwnerIdWithClientPaginated` and `countByOwnerIdWithClient` in the model
- document query parameters in README

## Testing
- `npm test` *(fails: mocha not found)*
- `npm install` *(fails: network access disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6859e21fb6a8832d809027238c7b6244