### PR TITLE
Fix remissions order

### DIFF
--- a/models/remissionsModel.js
+++ b/models/remissionsModel.js
@@ -64,7 +64,7 @@ const findByOwnerIdWithClient = (ownerId) => {
       JOIN projects p ON r.project_id = p.id
       JOIN clients c ON p.client_id = c.id
       WHERE r.owner_id = ?
-      ORDER BY r.created_at ASC`;
+      ORDER BY r.created_at DESC`;
     db.query(sql, [ownerId], (err, rows) => {
       if (err) return reject(err);
       const result = rows.map(row => {
@@ -116,7 +116,7 @@ const findByOwnerIdWithClientPaginated = (
       JOIN projects p ON r.project_id = p.id
       JOIN clients c ON p.client_id = c.id
       WHERE r.owner_id = ? ${clause}
-      ORDER BY r.created_at ASC
+      ORDER BY r.created_at DESC
       LIMIT ? OFFSET ?`;
     db.query(sql, [ownerId, ...params, parseInt(limit, 10), offset], (err, rows) => {
       if (err) return reject(err);


### PR DESCRIPTION
## Summary
- sort remissions by newest first when filtering by owner

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859e5971aac832da92e04e3566d534f