### PR TITLE
Add material types endpoint

### DIFF
--- a/API_NODE.postman_collection.json
+++ b/API_NODE.postman_collection.json
@@ -708,6 +708,35 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "Material Types",
+      "item": [
+        {
+          "name": "List Material Types",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/material-types",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "material-types"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ]
 }

--- a/API_NODE_New.postman_collection.json
+++ b/API_NODE_New.postman_collection.json
@@ -1275,6 +1275,35 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "Material Types",
+      "item": [
+        {
+          "name": "List Material Types",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/material-types",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "material-types"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ]
 }

--- a/API_NODE_Scenario.postman_collection.json
+++ b/API_NODE_Scenario.postman_collection.json
@@ -810,6 +810,35 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "Material Types",
+      "item": [
+        {
+          "name": "List Material Types",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}"
+              }
+            ],
+            "url": {
+              "raw": "http://localhost:3000/material-types",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "material-types"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ]
 }

--- a/api.js
+++ b/api.js
@@ -27,6 +27,7 @@ const ownerCompaniesRouter = require('./routes/ownerCompanies');
 const remissionStyleRouter = require('./routes/remissionStyle');
 const remissionsRouter = require('./routes/remissions');
 const menusRouter = require('./routes/menus');
+const materialTypesRouter = require('./routes/materialTypes');
 
 const app = express();
 app.use(passport.initialize());
@@ -119,6 +120,7 @@ app.use('/', authenticateJWT, accessoriesRouter);
 app.use('/', authenticateJWT, playsetsRouter);
 app.use('/', authenticateJWT, playsetAccessoriesRouter);
 app.use('/', authenticateJWT, materialAttributesRouter);
+app.use('/', authenticateJWT, materialTypesRouter);
 app.use('/', authenticateJWT, clientsRouter);
 app.use('/', authenticateJWT, projectsRouter);
 app.use('/', authenticateJWT, installationCostsRouter);

--- a/models/materialTypesModel.js
+++ b/models/materialTypesModel.js
@@ -1,0 +1,16 @@
+const db = require('../db');
+
+/**
+ * Obtiene todos los tipos de material.
+ * @returns {Promise<object[]>} Listado de tipos de material.
+ */
+const findAll = () => {
+  return new Promise((resolve, reject) => {
+    db.query('SELECT * FROM material_types', (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+};
+
+module.exports = { findAll };

--- a/routes/materialTypes.js
+++ b/routes/materialTypes.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const MaterialTypes = require('../models/materialTypesModel');
+const router = express.Router();
+
+/**
+ * @openapi
+ * /material-types:
+ *   get:
+ *     summary: Listar tipos de material
+ *     tags:
+ *       - MaterialTypes
+ *     responses:
+ *       200:
+ *         description: Lista de tipos de material
+ */
+router.get('/material-types', async (req, res) => {
+  try {
+    const types = await MaterialTypes.findAll();
+    res.json(types);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+module.exports = router;

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -8,6 +8,7 @@ const projects = require('../models/projectsModel');
 const installationCosts = require('../models/installationCostsModel');
 const ownerCompanies = require('../models/ownerCompaniesModel');
 const menus = require('../models/menusModel');
+const materialTypes = require('../models/materialTypesModel');
 
 describe('Model exports', () => {
   it('materials model exposes CRUD functions', () => {
@@ -57,6 +58,10 @@ describe('Model exports', () => {
   it('menus model exposes CRUD functions', () => {
     expect(menus.createMenu).to.be.a('function');
     expect(menus.getMenuTree).to.be.a('function');
+  });
+
+  it('materialTypes model exposes findAll function', () => {
+    expect(materialTypes.findAll).to.be.a('function');
   });
 });
 

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -10,6 +10,7 @@ const projectsRouter = require('../routes/projects');
 const installationCostsRouter = require('../routes/installationCosts');
 const ownerCompaniesRouter = require('../routes/ownerCompanies');
 const remissionStyleRouter = require('../routes/remissionStyle');
+const materialTypesRouter = require('../routes/materialTypes');
 
 describe('Route definitions', () => {
   it('materials router has routes configured', () => {
@@ -68,5 +69,9 @@ describe('Route definitions', () => {
 
   it('remission style router has routes configured', () => {
     expect(remissionStyleRouter.stack).to.be.an('array').that.is.not.empty;
+  });
+
+  it('material types router has routes configured', () => {
+    expect(materialTypesRouter.stack).to.be.an('array').that.is.not.empty;
   });
 });


### PR DESCRIPTION
## Summary
- add MaterialTypes model and route
- expose the new route from the main app
- update tests for new route and model
- append material types request in Postman collections

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a03080e64832da7ad046c77517c80