### PR TITLE
Add material type to materials endpoint

### DIFF
--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS raw_materials (
     width_m DECIMAL(10,2),
     length_m DECIMAL(10,2),
     price DECIMAL(10,2),
+    material_type_id INT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 );
@@ -202,6 +203,9 @@ CREATE TABLE IF NOT EXISTS menus (
 ALTER TABLE raw_materials
   ADD COLUMN owner_id INT,
   ADD CONSTRAINT FOREIGN KEY (owner_id) REFERENCES owner_companies(id);
+ALTER TABLE raw_materials
+  ADD COLUMN material_type_id INT,
+  ADD CONSTRAINT FOREIGN KEY (material_type_id) REFERENCES material_types(id);
 
 ALTER TABLE material_attributes
   ADD COLUMN owner_id INT,

--- a/models/materialsModel.js
+++ b/models/materialsModel.js
@@ -18,14 +18,15 @@ const createMaterial = (
   width,
   length,
   price,
+  materialTypeId,
   ownerId = 1
 ) => {
   return new Promise((resolve, reject) => {
     const sql =
-      'INSERT INTO raw_materials (name, description, thickness_mm, width_m, length_m, price, owner_id) VALUES (?, ?, ?, ?, ?, ?, ?)';
+      'INSERT INTO raw_materials (name, description, thickness_mm, width_m, length_m, price, material_type_id, owner_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)';
     db.query(
       sql,
-      [name, description, thickness, width, length, price, ownerId],
+      [name, description, thickness, width, length, price, materialTypeId, ownerId],
       (err, result) => {
         if (err) return reject(err);
         resolve({
@@ -36,6 +37,7 @@ const createMaterial = (
           width_m: width,
           length_m: length,
           price,
+          material_type_id: materialTypeId,
           owner_id: ownerId
         });
       }
@@ -134,14 +136,15 @@ const updateMaterial = (
   thickness,
   width,
   length,
-  price
+  price,
+  materialTypeId
 ) => {
   return new Promise((resolve, reject) => {
     const sql =
-      'UPDATE raw_materials SET name = ?, description = ?, thickness_mm = ?, width_m = ?, length_m = ?, price = ? WHERE id = ?';
+      'UPDATE raw_materials SET name = ?, description = ?, thickness_mm = ?, width_m = ?, length_m = ?, price = ?, material_type_id = ? WHERE id = ?';
     db.query(
       sql,
-      [name, description, thickness, width, length, price, id],
+      [name, description, thickness, width, length, price, materialTypeId, id],
       (err, result) => {
         if (err) return reject(err);
         resolve(result);

--- a/routes/materials.js
+++ b/routes/materials.js
@@ -74,6 +74,8 @@ const router = express.Router();
  *                 type: number
  *               price:
  *                 type: number
+ *               material_type_id:
+ *                 type: integer
  *     responses:
  *       201:
  *         description: Material creado
@@ -116,6 +118,8 @@ const router = express.Router();
  *                 type: number
  *               price:
  *                 type: number
+ *               material_type_id:
+ *                 type: integer
  *     responses:
  *       200:
  *         description: Material actualizado
@@ -182,7 +186,8 @@ router.post('/materials', async (req, res) => {
       thickness_mm,
       width_m,
       length_m,
-      price
+      price,
+      material_type_id
     } = req.body;
     const material = await Materials.createMaterial(
       name,
@@ -191,6 +196,7 @@ router.post('/materials', async (req, res) => {
       width_m,
       length_m,
       price,
+      material_type_id,
       1
     );
     res.status(201).json(material);
@@ -211,7 +217,8 @@ router.put('/materials/:id', async (req, res) => {
       thickness_mm,
       width_m,
       length_m,
-      price
+      price,
+      material_type_id
     } = req.body;
     const material = await Materials.findById(req.params.id);
     if (!material)
@@ -223,7 +230,8 @@ router.put('/materials/:id', async (req, res) => {
       thickness_mm,
       width_m,
       length_m,
-      price
+      price,
+      material_type_id
     );
     res.json({ message: 'Material actualizado' });
   } catch (error) {

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -90,6 +90,7 @@ describe('Model logic', () => {
       2,
       3,
       20,
+      2,
       1
     );
 
@@ -101,6 +102,7 @@ describe('Model logic', () => {
       width_m: 2,
       length_m: 3,
       price: 20,
+      material_type_id: 2,
       owner_id: 1
     });
   });


### PR DESCRIPTION
## Summary
- support new `material_type_id` column for raw_materials
- insert and update `material_type_id` when creating/updating materials
- document `material_type_id` in Swagger docs
- adjust tests for `createMaterial` changes
- update migration schema to add the field

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a0512c740832db553c1dd2fd9d84c