### PR TITLE
Include cost and price in accessories list

### DIFF
--- a/routes/accessories.js
+++ b/routes/accessories.js
@@ -78,7 +78,8 @@ const router = express.Router();
  */
 router.get('/accessories', async (req, res) => {
   try {
-    const accessories = await Accessories.findAll();
+    const ownerId = parseInt(req.query.owner_id || '1', 10);
+    const accessories = await Accessories.findByOwnerWithCosts(ownerId);
     res.json(accessories);
   } catch (error) {
     res.status(500).json({ message: error.message });


### PR DESCRIPTION
## Summary
- compute accessory cost and price per owner
- expose helper to fetch accessories with their costs
- return accessories with `cost` and `price` in API using `owner_id` query

## Testing
- `npm test` *(fails: mocha not found)*
- `./run-tests.sh` *(fails: network access for npm install)*

------
https://chatgpt.com/codex/tasks/task_e_6862f70b2b78832d875194f11b5d2ee0