### PR TITLE
Support new accessory_materials fields

### DIFF
--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -33,13 +33,18 @@ CREATE TABLE IF NOT EXISTS accessory_materials (
     id INT AUTO_INCREMENT PRIMARY KEY,
     accessory_id INT NOT NULL,
     material_id INT NOT NULL,
+    costo DECIMAL(10,2),
+    porcentaje_ganancia DECIMAL(5,2),
+    precio DECIMAL(10,2),
     quantity INT,
     width_m DECIMAL(10,2),
     length_m DECIMAL(10,2),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    owner_id INT,
     FOREIGN KEY (accessory_id) REFERENCES accessories(id),
-    FOREIGN KEY (material_id) REFERENCES raw_materials(id)
+    FOREIGN KEY (material_id) REFERENCES raw_materials(id),
+    FOREIGN KEY (owner_id) REFERENCES owner_companies(id)
 );
 
 CREATE TABLE IF NOT EXISTS playsets (
@@ -215,9 +220,7 @@ ALTER TABLE accessories
   ADD COLUMN owner_id INT,
   ADD CONSTRAINT FOREIGN KEY (owner_id) REFERENCES owner_companies(id);
 
-ALTER TABLE accessory_materials
-  ADD COLUMN owner_id INT,
-  ADD CONSTRAINT FOREIGN KEY (owner_id) REFERENCES owner_companies(id);
+-- owner_id column included in initial table definition
 
 ALTER TABLE playsets
   ADD COLUMN owner_id INT,

--- a/models/accessoryMaterialsModel.js
+++ b/models/accessoryMaterialsModel.js
@@ -10,16 +10,47 @@ const db = require('../db');
  * @returns {Promise<object>} Registro creado con su ID.
  * @throws {Error} Si ocurre un error en la inserción.
  */
-const linkMaterial = (accessoryId, materialId, quantity, width, length, ownerId = 1) => {
+const linkMaterial = (
+  accessoryId,
+  materialId,
+  cost,
+  profitPercentage,
+  price,
+  quantity,
+  width,
+  length,
+  ownerId = 1
+) => {
   return new Promise((resolve, reject) => {
     const sql =
-      'INSERT INTO accessory_materials (accessory_id, material_id, quantity, width_m, length_m, owner_id) VALUES (?, ?, ?, ?, ?, ?)';
+      'INSERT INTO accessory_materials (accessory_id, material_id, costo, porcentaje_ganancia, precio, quantity, width_m, length_m, owner_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)';
     db.query(
       sql,
-      [accessoryId, materialId, quantity, width, length, ownerId],
+      [
+        accessoryId,
+        materialId,
+        cost,
+        profitPercentage,
+        price,
+        quantity,
+        width,
+        length,
+        ownerId
+      ],
       (err, result) => {
         if (err) return reject(err);
-        resolve({ id: result.insertId, accessoryId, materialId, quantity, width, length, owner_id: ownerId });
+        resolve({
+          id: result.insertId,
+          accessoryId,
+          materialId,
+          cost,
+          profit_percentage: profitPercentage,
+          price,
+          quantity,
+          width,
+          length,
+          owner_id: ownerId
+        });
       }
     );
   });
@@ -42,19 +73,25 @@ const linkMaterialsBatch = (accessoryId, materials, ownerId = 1) => {
     const values = materials.map((m) => [
       accessoryId,
       m.material_id,
+      m.cost,
+      m.profit_percentage,
+      m.price,
       m.quantity,
       m.width,
       m.length,
       ownerId
     ]);
     const sql =
-      'INSERT INTO accessory_materials (accessory_id, material_id, quantity, width_m, length_m, owner_id) VALUES ?';
+      'INSERT INTO accessory_materials (accessory_id, material_id, costo, porcentaje_ganancia, precio, quantity, width_m, length_m, owner_id) VALUES ?';
     db.query(sql, [values], (err, result) => {
       if (err) return reject(err);
       const inserted = materials.map((m, idx) => ({
         id: result.insertId + idx,
         accessoryId,
         materialId: m.material_id,
+        cost: m.cost,
+        profit_percentage: m.profit_percentage,
+        price: m.price,
         quantity: m.quantity,
         width: m.width,
         length: m.length,

--- a/routes/accessoryMaterials.js
+++ b/routes/accessoryMaterials.js
@@ -102,22 +102,34 @@ router.post('/accessory-materials', async (req, res) => {
       return res.status(201).json(withCost);
     }
 
-    const { accessoryId, materialId, quantity, width, length } = req.body;
+    const {
+      accessoryId,
+      materialId,
+      cost,
+      profit_percentage,
+      price,
+      quantity,
+      width,
+      length
+    } = req.body;
     const link = await AccessoryMaterials.linkMaterial(
       accessoryId,
       materialId,
+      cost,
+      profit_percentage,
+      price,
       quantity,
       width,
       length,
       1
     );
-    const cost = await AccessoryMaterials.calculateCost(
+    const calculatedCost = await AccessoryMaterials.calculateCost(
       materialId,
       width,
       length,
       quantity
     );
-    res.status(201).json({ ...link, cost });
+    res.status(201).json({ ...link, cost: calculatedCost });
   } catch (error) {
     res.status(500).json({ message: error.message });
   }


### PR DESCRIPTION
## Summary
- extend accessory materials model to store cost, price and profit percentage
- adjust accessory materials routes to handle new properties
- update DB schema for accessory_materials with new fields

## Testing
- `./run-tests.sh` *(fails: npm install requires internet)*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fe4edab4832db54b522cc0f0dafb