### PR TITLE
Add pagination for accessories endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ DB_NAME=demodb
 - `GET /materials` Lista materiales (protegido).
   - Parámetros opcionales: `page`, `limit` y `search` para paginar y filtrar por texto.
 - `GET /accessories` Lista accesorios (protegido).
+  - Parámetros opcionales: `page` y `limit` para paginar los resultados.
 - `GET /playsets` Lista playsets (protegido).
 - `GET /playsets/:id/cost` Calcula el costo total de un playset.
 - `POST /playset-accessories` Crea vínculo de accesorio a playset (protegido).

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -22,6 +22,8 @@ describe('Model exports', () => {
     expect(accessories.createAccessory).to.be.a('function');
     expect(accessories.findById).to.be.a('function');
     expect(accessories.findAll).to.be.a('function');
+    expect(accessories.findByOwnerWithCostsPaginated).to.be.a('function');
+    expect(accessories.countByOwner).to.be.a('function');
   });
 
   it('playsets model exposes CRUD functions', () => {


### PR DESCRIPTION
## Summary
- support pagination on `/accessories`
- document new pagination params in README and OpenAPI comments
- expose `findByOwnerWithCostsPaginated` and `countByOwner`
- verify model exports in tests

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68630c115c24832da27c90b4b3990144