### PR TITLE
Add materials listing endpoint

### DIFF
--- a/models/accessoryMaterialsModel.js
+++ b/models/accessoryMaterialsModel.js
@@ -241,6 +241,31 @@ const findMaterialsCostByAccessory = (accessoryId) => {
 };
 
 /**
+ * Obtiene la lista de materiales asociados a un accesorio.
+ * @param {number} accessoryId - ID del accesorio.
+ * @returns {Promise<object[]>} Materiales vinculados al accesorio.
+ */
+const findMaterialsByAccessory = (accessoryId) => {
+  return new Promise((resolve, reject) => {
+    const sql = `
+      SELECT a.id AS accessory_id, a.name AS accessory_name,
+             am.id AS link_id, am.quantity, am.width_m, am.length_m,
+             am.costo, am.porcentaje_ganancia, am.precio,
+             rm.id AS material_id, rm.name AS material_name, rm.description,
+             rm.thickness_mm, rm.width_m AS material_width, rm.length_m AS material_length,
+             rm.price
+      FROM accessories a
+      JOIN accessory_materials am ON a.id = am.accessory_id
+      JOIN raw_materials rm ON rm.id = am.material_id
+      WHERE a.id = ?`;
+    db.query(sql, [accessoryId], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+};
+
+/**
  * Actualiza la cantidad de un vínculo existente.
  * @param {number} id - ID del vínculo.
  * @param {number} quantity - Nueva cantidad.
@@ -279,6 +304,7 @@ module.exports = {
   findAll,
   findAccessoriesWithMaterialsCost,
   findMaterialsCostByAccessory,
+  findMaterialsByAccessory,
   updateLink,
   deleteLink,
   calculateCost

--- a/routes/accessoryMaterials.js
+++ b/routes/accessoryMaterials.js
@@ -64,6 +64,23 @@ const router = express.Router();
  *       404:
  *         description: Accesorio no encontrado
  */
+/**
+ * /accessories/{id}/materials:
+ *   get:
+ *     summary: Listar materiales de un accesorio
+ *     tags:
+ *       - AccessoryMaterials
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Lista de materiales
+ *       404:
+ *         description: Accesorio no encontrado
+ */
 router.post('/accessory-materials', async (req, res) => {
   try {
     if (Array.isArray(req.body.materials)) {
@@ -143,6 +160,38 @@ router.get('/accessory-materials', async (req, res) => {
   try {
     const links = await AccessoryMaterials.findAll();
     res.json(links);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+/**
+ * Obtiene los materiales vinculados a un accesorio.
+ * @route GET /accessories/:id/materials
+ */
+router.get('/accessories/:id/materials', async (req, res) => {
+  try {
+    const rows = await AccessoryMaterials.findMaterialsByAccessory(req.params.id);
+    if (rows.length === 0)
+      return res.status(404).json({ message: 'Accesorio no encontrado' });
+    const { accessory_id, accessory_name } = rows[0];
+    const materials = rows.map((row) => ({
+      link_id: row.link_id,
+      material_id: row.material_id,
+      material_name: row.material_name,
+      description: row.description,
+      thickness_mm: row.thickness_mm,
+      width_m: row.material_width,
+      length_m: row.material_length,
+      price: row.price,
+      quantity: row.quantity,
+      width_m_used: row.width_m,
+      length_m_used: row.length_m,
+      cost: row.costo,
+      profit_percentage: row.porcentaje_ganancia,
+      price_override: row.precio
+    }));
+    res.json({ accessory_id, accessory_name, materials });
   } catch (error) {
     res.status(500).json({ message: error.message });
   }


### PR DESCRIPTION
## Summary
- add a `findMaterialsByAccessory` query
- expose new `/accessories/:id/materials` endpoint

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686330b47994832dbd15465049da38d5