### PR TITLE
Add material type details in accessory materials endpoint

### DIFF
--- a/models/accessoryMaterialsModel.js
+++ b/models/accessoryMaterialsModel.js
@@ -253,10 +253,12 @@ const findMaterialsByAccessory = (accessoryId) => {
              am.costo, am.porcentaje_ganancia, am.precio,
              rm.id AS material_id, rm.name AS material_name, rm.description,
              rm.thickness_mm, rm.width_m AS material_width, rm.length_m AS material_length,
-             rm.price
+             rm.price, rm.material_type_id,
+             mt.description AS material_type_description
       FROM accessories a
       JOIN accessory_materials am ON a.id = am.accessory_id
       JOIN raw_materials rm ON rm.id = am.material_id
+      LEFT JOIN material_types mt ON rm.material_type_id = mt.id
       WHERE a.id = ?`;
     db.query(sql, [accessoryId], (err, rows) => {
       if (err) return reject(err);

--- a/routes/accessoryMaterials.js
+++ b/routes/accessoryMaterials.js
@@ -179,6 +179,8 @@ router.get('/accessories/:id/materials', async (req, res) => {
       link_id: row.link_id,
       material_id: row.material_id,
       material_name: row.material_name,
+      material_type_id: row.material_type_id,
+      material_type_description: row.material_type_description,
       description: row.description,
       thickness_mm: row.thickness_mm,
       width_m: row.material_width,


### PR DESCRIPTION
## Summary
- include `material_type_id` and `material_type_description` in accessory-material listing
- return these new fields from `/accessories/:id/materials`

## Testing
- `./run-tests.sh` *(fails: 403 Forbidden when installing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68633f6f2a58832db4ce58102a389b79