### PR TITLE
Implement update for accessory materials

### DIFF
--- a/models/accessoryMaterialsModel.js
+++ b/models/accessoryMaterialsModel.js
@@ -285,6 +285,54 @@ const updateLink = (id, quantity) => {
 };
 
 /**
+ * Actualiza todos los datos de un vínculo existente.
+ * @param {number} id - ID del vínculo.
+ * @param {number} accessoryId - Nuevo ID del accesorio.
+ * @param {number} materialId - Nuevo ID del material.
+ * @param {number} cost - Costo del material.
+ * @param {number} profitPercentage - Porcentaje de ganancia.
+ * @param {number} price - Precio del material.
+ * @param {number} quantity - Cantidad utilizada.
+ * @param {number} width - Ancho utilizado en metros.
+ * @param {number} length - Largo utilizado en metros.
+ * @returns {Promise<object>} Resultado de la actualización.
+ */
+const updateLinkData = (
+  id,
+  accessoryId,
+  materialId,
+  cost,
+  profitPercentage,
+  price,
+  quantity,
+  width,
+  length
+) => {
+  return new Promise((resolve, reject) => {
+    const sql =
+      'UPDATE accessory_materials SET accessory_id = ?, material_id = ?, costo = ?, porcentaje_ganancia = ?, precio = ?, quantity = ?, width_m = ?, length_m = ? WHERE id = ?';
+    db.query(
+      sql,
+      [
+        accessoryId,
+        materialId,
+        cost,
+        profitPercentage,
+        price,
+        quantity,
+        width,
+        length,
+        id
+      ],
+      (err, result) => {
+        if (err) return reject(err);
+        resolve(result);
+      }
+    );
+  });
+};
+
+/**
  * Elimina un vínculo entre accesorio y material.
  * @param {number} id - Identificador del vínculo.
  * @returns {Promise<object>} Resultado de la operación.
@@ -308,6 +356,7 @@ module.exports = {
   findMaterialsCostByAccessory,
   findMaterialsByAccessory,
   updateLink,
+  updateLinkData,
   deleteLink,
   calculateCost
 };

--- a/routes/accessoryMaterials.js
+++ b/routes/accessoryMaterials.js
@@ -48,6 +48,40 @@ const router = express.Router();
  *       201:
  *         description: Vinculo creado
  *
+ * /accessory-materials/{id}:
+ *   put:
+ *     summary: Actualizar vinculo
+ *     tags:
+ *       - AccessoryMaterials
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               accessoryId:
+ *                 type: integer
+ *               materialId:
+ *                 type: integer
+ *               cost:
+ *                 type: number
+ *               profit_percentage:
+ *                 type: number
+ *               price:
+ *                 type: number
+ *               quantity:
+ *                 type: number
+ *               width:
+ *                 type: number
+ *               length:
+ *                 type: number
+ *     responses:
+ *       200:
+ *         description: Vinculo actualizado
+ *       404:
+ *         description: Vinculo no encontrado
+ *
  * /accessories/{id}/materials-cost:
  *   get:
  *     summary: Obtener costo de materiales de un accesorio
@@ -160,6 +194,41 @@ router.get('/accessory-materials', async (req, res) => {
   try {
     const links = await AccessoryMaterials.findAll();
     res.json(links);
+  } catch (error) {
+    res.status(500).json({ message: error.message });
+  }
+});
+
+/**
+ * Actualiza un vínculo accesorio-material.
+ * @route PUT /accessory-materials/:id
+ */
+router.put('/accessory-materials/:id', async (req, res) => {
+  try {
+    const {
+      accessoryId,
+      materialId,
+      cost,
+      profit_percentage,
+      price,
+      quantity,
+      width,
+      length
+    } = req.body;
+    const link = await AccessoryMaterials.findById(req.params.id);
+    if (!link) return res.status(404).json({ message: 'Vinculo no encontrado' });
+    await AccessoryMaterials.updateLinkData(
+      req.params.id,
+      accessoryId,
+      materialId,
+      cost,
+      profit_percentage,
+      price,
+      quantity,
+      width,
+      length
+    );
+    res.json({ message: 'Vinculo actualizado' });
   } catch (error) {
     res.status(500).json({ message: error.message });
   }


### PR DESCRIPTION
## Summary
- add model function to update full accessory-material link
- expose new `/accessory-materials/:id` PUT route
- document update route in OpenAPI docs

## Testing
- `./run-tests.sh` *(fails: npm install requires internet access)*

------
https://chatgpt.com/codex/tasks/task_e_686343771328832db451e0fb37e7d2ba