### PR TITLE
Add batch update for accessory materials

### DIFF
--- a/models/accessoryMaterialsModel.js
+++ b/models/accessoryMaterialsModel.js
@@ -347,6 +347,24 @@ const deleteLink = (id) => {
   });
 };
 
+/**
+ * Elimina todas las relaciones de materiales para un accesorio.
+ * @param {number} accessoryId - Identificador del accesorio.
+ * @returns {Promise<object>} Resultado de la operación.
+ */
+const deleteByAccessory = (accessoryId) => {
+  return new Promise((resolve, reject) => {
+    db.query(
+      'DELETE FROM accessory_materials WHERE accessory_id = ?',
+      [accessoryId],
+      (err, result) => {
+        if (err) return reject(err);
+        resolve(result);
+      }
+    );
+  });
+};
+
 module.exports = {
   linkMaterial,
   linkMaterialsBatch,
@@ -357,6 +375,7 @@ module.exports = {
   findMaterialsByAccessory,
   updateLink,
   updateLinkData,
+  deleteByAccessory,
   deleteLink,
   calculateCost
 };


### PR DESCRIPTION
## Summary
- add `deleteByAccessory` helper to remove materials of one accessory
- allow PUT `/accessory-materials/:id` to accept an array to replace materials
- document the new request shape in Swagger comments

## Testing
- `bash run-tests.sh` *(fails: npm install requires network)*

------
https://chatgpt.com/codex/tasks/task_e_686348aa3fe8832da3aa21235604351d