### PR TITLE
Improve accessory components endpoint

### DIFF
--- a/routes/accessoryComponents.js
+++ b/routes/accessoryComponents.js
@@ -31,7 +31,11 @@ router.get('/accessory-components', async (req, res) => {
 // List components of a parent accessory
 router.get('/accessories/:id/components', async (req, res) => {
   try {
-    const rows = await AccessoryComponents.findByParent(req.params.id);
+    const ownerId = parseInt(req.query.owner_id || '1', 10);
+    const rows = await AccessoryComponents.findByParentDetailed(
+      req.params.id,
+      ownerId
+    );
     res.json(rows);
   } catch (err) {
     res.status(500).json({ message: err.message });

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -30,6 +30,7 @@ describe('Model exports', () => {
   it('accessory components model exposes basic functions', () => {
     expect(accessoryComponents.createComponentLink).to.be.a('function');
     expect(accessoryComponents.findAll).to.be.a('function');
+    expect(accessoryComponents.findByParentDetailed).to.be.a('function');
     expect(accessoryComponents.deleteLink).to.be.a('function');
   });
 


### PR DESCRIPTION
## Summary
- add new `findByParentDetailed` in accessoryComponentsModel to include child details and cost
- export it via route `/accessories/:id/components`
- validate the model export with updated tests

## Testing
- `./run-tests.sh` *(fails: 403 Forbidden due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_68648797cbd8832dbe888892017f42e4