### PR TITLE
Add accessory cost endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ DB_NAME=demodb
   - Parámetros opcionales: `page`, `limit` y `search` para paginar y filtrar por texto.
 - `GET /accessories` Lista accesorios (protegido).
   - Parámetros opcionales: `page` y `limit` para paginar los resultados.
+- `GET /accessories/:id/cost` Calcula el costo y precio de un accesorio.
 - `GET /playsets` Lista playsets (protegido).
 - `GET /playsets/:id/cost` Calcula el costo total de un playset.
 - `POST /playset-accessories` Crea vínculo de accesorio a playset (protegido).


### PR DESCRIPTION
## Summary
- expose `/accessories/:id/cost` route to retrieve the cost and price of a single accessory
- document new endpoint in README

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865776697a0832d87bd5753f789646b