### PR TITLE
Add bulk accessory component update

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ DB_NAME=demodb
   - Parámetros opcionales: `page`, `limit` y `search` para paginar y filtrar por texto.
 - `GET /accessories` Lista accesorios (protegido).
   - Parámetros opcionales: `page` y `limit` para paginar los resultados.
+- `GET /accessories/:id` Obtiene un accesorio con sus materiales y componentes.
 - `GET /accessories/:id/cost` Calcula el costo y precio de un accesorio.
+- `PUT /accessories/:id/components` Reemplaza los componentes de un accesorio.
+  - Envía un arreglo `components` con `accessory_id` y `quantity`.
 - `GET /playsets` Lista playsets (protegido).
 - `GET /playsets/:id/cost` Calcula el costo total de un playset.
 - `POST /playset-accessories` Crea vínculo de accesorio a playset (protegido).

--- a/routes/accessories.js
+++ b/routes/accessories.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const Accessories = require('../models/accessoriesModel');
 const OwnerCompanies = require('../models/ownerCompaniesModel');
+const AccessoryMaterials = require('../models/accessoryMaterialsModel');
+const AccessoryComponents = require('../models/accessoryComponentsModel');
 const router = express.Router();
 
 /**
@@ -64,6 +66,25 @@ const router = express.Router();
  *     responses:
  *       200:
  *         description: Accesorio encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: integer
+ *                 name:
+ *                   type: string
+ *                 description:
+ *                   type: string
+ *                 materials:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                 accessories:
+ *                   type: array
+ *                   items:
+ *                     type: object
  *       404:
  *         description: Accesorio no encontrado
  *   put:
@@ -130,8 +151,17 @@ router.get('/accessories', async (req, res) => {
 router.get('/accessories/:id', async (req, res) => {
   try {
     const accessory = await Accessories.findById(req.params.id);
-    if (!accessory) return res.status(404).json({ message: 'Accesorio no encontrado' });
-    res.json(accessory);
+    if (!accessory)
+      return res.status(404).json({ message: 'Accesorio no encontrado' });
+    const ownerId = parseInt(req.query.owner_id || '1', 10);
+    const materials = await AccessoryMaterials.findMaterialsByAccessory(
+      accessory.id
+    );
+    const accessories = await AccessoryComponents.findByParentDetailed(
+      accessory.id,
+      ownerId
+    );
+    res.json({ ...accessory, materials, accessories });
   } catch (error) {
     res.status(500).json({ message: error.message });
   }

--- a/routes/accessoryComponents.js
+++ b/routes/accessoryComponents.js
@@ -42,6 +42,33 @@ router.get('/accessories/:id/components', async (req, res) => {
   }
 });
 
+// Replace components of a parent accessory
+router.put('/accessories/:id/components', async (req, res) => {
+  try {
+    const parentId = Number(req.params.id);
+    const components = req.body.components;
+    if (isNaN(parentId) || !Array.isArray(components))
+      return res.status(400).json({ message: 'Datos incompletos' });
+
+    for (const c of components) {
+      if (typeof c.accessory_id !== 'number')
+        return res.status(400).json({ message: 'accessory_id requerido' });
+      if (c.quantity !== undefined && c.quantity !== null && typeof c.quantity !== 'number')
+        return res.status(400).json({ message: 'quantity invalido' });
+    }
+
+    await AccessoryComponents.deleteByParent(parentId);
+    const inserted = await AccessoryComponents.createComponentLinksBatch(
+      parentId,
+      components,
+      1
+    );
+    res.json(inserted);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
 // Delete link
 router.delete('/accessory-components/:id', async (req, res) => {
   try {

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -29,8 +29,10 @@ describe('Model exports', () => {
 
   it('accessory components model exposes basic functions', () => {
     expect(accessoryComponents.createComponentLink).to.be.a('function');
+    expect(accessoryComponents.createComponentLinksBatch).to.be.a('function');
     expect(accessoryComponents.findAll).to.be.a('function');
     expect(accessoryComponents.findByParentDetailed).to.be.a('function');
+    expect(accessoryComponents.deleteByParent).to.be.a('function');
     expect(accessoryComponents.deleteLink).to.be.a('function');
   });
 

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -45,6 +45,16 @@ describe('Route definitions', () => {
     expect(accessoryComponentsRouter.stack).to.be.an('array').that.is.not.empty;
   });
 
+  it('accessory components router registers replace route', () => {
+    const hasRoute = accessoryComponentsRouter.stack.some(
+      layer =>
+        layer.route &&
+        layer.route.path === '/accessories/:id/components' &&
+        layer.route.methods.put
+    );
+    expect(hasRoute).to.be.true;
+  });
+
   it('playset accessories router has routes configured', () => {
     expect(playsetAccessoriesRouter.stack).to.be.an('array').that.is.not.empty;
   });


### PR DESCRIPTION
## Summary
- handle bulk creation of accessory components
- expose helper functions in accessoryComponents model
- add route to replace components of an accessory
- show materials and components when retrieving an accessory
- document new endpoints
- ensure tests cover new model functions and route

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68658095602c832d81bde43565671bc1