### PR TITLE
Persist accessory pricing

### DIFF
--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -216,6 +216,19 @@ CREATE TABLE IF NOT EXISTS menus (
     FOREIGN KEY (parent_id) REFERENCES menus(id),
     FOREIGN KEY (owner_id) REFERENCES owner_companies(id)
 );
+CREATE TABLE IF NOT EXISTS accessory_pricing (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    accessory_id INT NOT NULL,
+    owner_id INT NOT NULL,
+    markup_percentage DECIMAL(10,2) DEFAULT 0,
+    total_materials_price DECIMAL(10,2) DEFAULT 0,
+    total_accessories_price DECIMAL(10,2) DEFAULT 0,
+    total_price DECIMAL(10,2) DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (accessory_id) REFERENCES accessories(id),
+    FOREIGN KEY (owner_id) REFERENCES owner_companies(id)
+);
 
 /* ──────────── Asociaciones con owner ──────────── */
 ALTER TABLE raw_materials

--- a/models/accessoryPricingModel.js
+++ b/models/accessoryPricingModel.js
@@ -1,0 +1,63 @@
+const db = require('../db');
+
+/**
+ * Inserta o actualiza la informacion de precios de un accesorio.
+ * @param {number} accessoryId - ID del accesorio.
+ * @param {number} ownerId - ID del propietario.
+ * @param {number} markup - Porcentaje de ganancia.
+ * @param {number} totalMaterials - Total de materiales.
+ * @param {number} totalAccessories - Total de accesorios.
+ * @param {number} total - Total general.
+ * @returns {Promise<object>} Resultado de la consulta.
+ */
+const upsertPricing = (
+  accessoryId,
+  ownerId,
+  markup,
+  totalMaterials,
+  totalAccessories,
+  total
+) => {
+  return new Promise((resolve, reject) => {
+    const sql = `INSERT INTO accessory_pricing
+      (accessory_id, owner_id, markup_percentage, total_materials_price, total_accessories_price, total_price)
+      VALUES (?, ?, ?, ?, ?, ?)
+      ON DUPLICATE KEY UPDATE
+        markup_percentage = VALUES(markup_percentage),
+        total_materials_price = VALUES(total_materials_price),
+        total_accessories_price = VALUES(total_accessories_price),
+        total_price = VALUES(total_price),
+        updated_at = CURRENT_TIMESTAMP`;
+    const params = [
+      accessoryId,
+      ownerId,
+      markup,
+      totalMaterials,
+      totalAccessories,
+      total
+    ];
+    db.query(sql, params, (err, result) => {
+      if (err) return reject(err);
+      resolve(result);
+    });
+  });
+};
+
+/**
+ * Obtiene los datos de precios de un accesorio.
+ * @param {number} accessoryId - ID del accesorio.
+ * @param {number} ownerId - ID del propietario.
+ * @returns {Promise<object|undefined>} Registro encontrado o undefined.
+ */
+const findByAccessory = (accessoryId, ownerId = 1) => {
+  return new Promise((resolve, reject) => {
+    const sql =
+      'SELECT * FROM accessory_pricing WHERE accessory_id = ? AND owner_id = ?';
+    db.query(sql, [accessoryId, ownerId], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows[0]);
+    });
+  });
+};
+
+module.exports = { upsertPricing, findByAccessory };

--- a/routes/accessoryComponents.js
+++ b/routes/accessoryComponents.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const AccessoryComponents = require('../models/accessoryComponentsModel');
 const router = express.Router();
+const { buildAccessoryPricing } = require("./accessoryMaterials");
 
 // Create component link
 router.post('/accessory-components', async (req, res) => {
@@ -58,12 +59,11 @@ router.put('/accessories/:id/components', async (req, res) => {
     }
 
     await AccessoryComponents.deleteByParent(parentId);
-    const inserted = await AccessoryComponents.createComponentLinksBatch(
-      parentId,
-      components,
-      1
-    );
-    res.json(inserted);
+    await AccessoryComponents.createComponentLinksBatch(parentId, components, 1);
+
+    const ownerId = parseInt(req.query.owner_id || '1', 10);
+    const pricing = await buildAccessoryPricing(parentId, ownerId);
+    res.json(pricing);
   } catch (err) {
     res.status(500).json({ message: err.message });
   }

--- a/routes/accessoryMaterials.js
+++ b/routes/accessoryMaterials.js
@@ -3,6 +3,7 @@ const AccessoryMaterials = require('../models/accessoryMaterialsModel');
 const AccessoryComponents = require('../models/accessoryComponentsModel');
 const OwnerCompanies = require('../models/ownerCompaniesModel');
 const router = express.Router();
+const AccessoryPricing = require("../models/accessoryPricingModel");
 
 const buildAccessoryPricing = async (accessoryId, ownerId = 1) => {
   const owner = await OwnerCompanies.findById(ownerId);
@@ -55,14 +56,27 @@ const buildAccessoryPricing = async (accessoryId, ownerId = 1) => {
     });
   }
 
+  const totalMaterialsPrice = +totalMaterials.toFixed(2);
+  const totalAccessoriesPrice = +totalAccessories.toFixed(2);
+  const totalPrice = +(totalMaterials + totalAccessories).toFixed(2);
+
+  await AccessoryPricing.upsertPricing(
+    accessoryId,
+    ownerId,
+    markup,
+    totalMaterialsPrice,
+    totalAccessoriesPrice,
+    totalPrice
+  );
+
   return {
     accessory_id: accessoryId,
     markup_percentage: markup,
     materials,
     accessories,
-    total_materials_price: +totalMaterials.toFixed(2),
-    total_accessories_price: +totalAccessories.toFixed(2),
-    total_price: +(totalMaterials + totalAccessories).toFixed(2)
+    total_materials_price: totalMaterialsPrice,
+    total_accessories_price: totalAccessoriesPrice,
+    total_price: totalPrice
   };
 };
 
@@ -479,3 +493,4 @@ router.get('/accessories/:id/materials-cost', async (req, res) => {
 });
 
 module.exports = router;
+module.exports.buildAccessoryPricing = buildAccessoryPricing;

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -10,6 +10,7 @@ const installationCosts = require('../models/installationCostsModel');
 const ownerCompanies = require('../models/ownerCompaniesModel');
 const menus = require('../models/menusModel');
 const materialTypes = require('../models/materialTypesModel');
+const accessoryPricing = require('../models/accessoryPricingModel');
 
 describe('Model exports', () => {
   it('materials model exposes CRUD functions', () => {
@@ -74,6 +75,11 @@ describe('Model exports', () => {
 
   it('materialTypes model exposes findAll function', () => {
     expect(materialTypes.findAll).to.be.a('function');
+  });
+
+  it('accessoryPricing model exposes upsert and find functions', () => {
+    expect(accessoryPricing.upsertPricing).to.be.a('function');
+    expect(accessoryPricing.findByAccessory).to.be.a('function');
   });
 });
 


### PR DESCRIPTION
## Summary
- create `accessory_pricing` table in schema
- add model for accessory pricing persistence
- store pricing data whenever accessory materials or components are updated
- expose pricing helper from accessoryMaterials router
- update tests to include new model

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865907a8e00832d9ea550c6e5a32f92