### PR TITLE
Implement full accessory payload storage

### DIFF
--- a/Modules/dbUtils.js
+++ b/Modules/dbUtils.js
@@ -1,0 +1,39 @@
+const db = require('../db');
+
+/**
+ * Checks if a column exists in a given table.
+ * @param {string} table - Table name.
+ * @param {string} column - Column name.
+ * @returns {Promise<boolean>} True if column exists.
+ */
+const columnExists = (table, column) => {
+  return new Promise((resolve, reject) => {
+    const sql = 'SHOW COLUMNS FROM ?? LIKE ?';
+    db.query(sql, [table, column], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows.length > 0);
+    });
+  });
+};
+
+/**
+ * Ensures that a column exists in the table, adding it if missing.
+ * @param {string} table - Table name.
+ * @param {string} column - Column name.
+ * @param {string} definition - Column definition used in ALTER TABLE.
+ * @returns {Promise<void>}
+ */
+const ensureColumn = async (table, column, definition) => {
+  const exists = await columnExists(table, column);
+  if (!exists) {
+    await new Promise((resolve, reject) => {
+      const sql = `ALTER TABLE ?? ADD COLUMN ?? ${definition}`;
+      db.query(sql, [table, column], err => {
+        if (err) return reject(err);
+        resolve();
+      });
+    });
+  }
+};
+
+module.exports = { columnExists, ensureColumn };

--- a/models/accessoryComponentsModel.js
+++ b/models/accessoryComponentsModel.js
@@ -1,17 +1,24 @@
 const db = require('../db');
 const Accessories = require('./accessoriesModel');
 
-const createComponentLink = (parentId, childId, quantity, ownerId = 1) => {
+const createComponentLink = (
+  parentId,
+  childId,
+  quantity,
+  childName,
+  ownerId = 1
+) => {
   return new Promise((resolve, reject) => {
-    const sql = `INSERT INTO accessory_components (parent_accessory_id, child_accessory_id, quantity, owner_id)
-                 VALUES (?, ?, ?, ?)`;
-    db.query(sql, [parentId, childId, quantity, ownerId], (err, result) => {
+    const sql = `INSERT INTO accessory_components (parent_accessory_id, child_accessory_id, quantity, child_accessory_name, owner_id)
+                 VALUES (?, ?, ?, ?, ?)`;
+    db.query(sql, [parentId, childId, quantity, childName, ownerId], (err, result) => {
       if (err) return reject(err);
       resolve({
         id: result.insertId,
         parent_accessory_id: parentId,
         child_accessory_id: childId,
         quantity,
+        child_name: childName,
         owner_id: ownerId
       });
     });
@@ -92,10 +99,11 @@ const createComponentLinksBatch = (parentId, components, ownerId = 1) => {
       parentId,
       c.accessory_id,
       c.quantity,
+      c.name,
       ownerId
     ]);
     const sql =
-      'INSERT INTO accessory_components (parent_accessory_id, child_accessory_id, quantity, owner_id) VALUES ?';
+      'INSERT INTO accessory_components (parent_accessory_id, child_accessory_id, quantity, child_accessory_name, owner_id) VALUES ?';
     db.query(sql, [values], (err, result) => {
       if (err) return reject(err);
       const inserted = components.map((c, idx) => ({
@@ -103,6 +111,7 @@ const createComponentLinksBatch = (parentId, components, ownerId = 1) => {
         parent_accessory_id: parentId,
         child_accessory_id: c.accessory_id,
         quantity: c.quantity,
+        child_name: c.name,
         owner_id: ownerId
       }));
       resolve(inserted);

--- a/models/accessoryMaterialsModel.js
+++ b/models/accessoryMaterialsModel.js
@@ -19,11 +19,13 @@ const linkMaterial = (
   quantity,
   width,
   length,
+  investment,
+  description,
   ownerId = 1
 ) => {
   return new Promise((resolve, reject) => {
     const sql =
-      'INSERT INTO accessory_materials (accessory_id, material_id, costo, porcentaje_ganancia, precio, quantity, width_m, length_m, owner_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)';
+      'INSERT INTO accessory_materials (accessory_id, material_id, costo, porcentaje_ganancia, precio, quantity, width_m, length_m, investment, descripcion_material, owner_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)';
     db.query(
       sql,
       [
@@ -35,6 +37,8 @@ const linkMaterial = (
         quantity,
         width,
         length,
+        investment,
+        description,
         ownerId
       ],
       (err, result) => {
@@ -49,6 +53,8 @@ const linkMaterial = (
           quantity,
           width,
           length,
+          investment,
+          description,
           owner_id: ownerId
         });
       }
@@ -79,10 +85,12 @@ const linkMaterialsBatch = (accessoryId, materials, ownerId = 1) => {
       m.quantity,
       m.width,
       m.length,
+      m.investment,
+      m.description,
       ownerId
     ]);
     const sql =
-      'INSERT INTO accessory_materials (accessory_id, material_id, costo, porcentaje_ganancia, precio, quantity, width_m, length_m, owner_id) VALUES ?';
+      'INSERT INTO accessory_materials (accessory_id, material_id, costo, porcentaje_ganancia, precio, quantity, width_m, length_m, investment, descripcion_material, owner_id) VALUES ?';
     db.query(sql, [values], (err, result) => {
       if (err) return reject(err);
       const inserted = materials.map((m, idx) => ({
@@ -95,6 +103,8 @@ const linkMaterialsBatch = (accessoryId, materials, ownerId = 1) => {
         quantity: m.quantity,
         width: m.width,
         length: m.length,
+        investment: m.investment,
+        description: m.description,
         owner_id: ownerId
       }));
       resolve(inserted);
@@ -316,11 +326,13 @@ const updateLinkData = (
   price,
   quantity,
   width,
-  length
+  length,
+  investment,
+  description
 ) => {
   return new Promise((resolve, reject) => {
     const sql =
-      'UPDATE accessory_materials SET accessory_id = ?, material_id = ?, costo = ?, porcentaje_ganancia = ?, precio = ?, quantity = ?, width_m = ?, length_m = ? WHERE id = ?';
+      'UPDATE accessory_materials SET accessory_id = ?, material_id = ?, costo = ?, porcentaje_ganancia = ?, precio = ?, quantity = ?, width_m = ?, length_m = ?, investment = ?, descripcion_material = ? WHERE id = ?';
     db.query(
       sql,
       [
@@ -332,6 +344,8 @@ const updateLinkData = (
         quantity,
         width,
         length,
+        investment,
+        description,
         id
       ],
       (err, result) => {

--- a/routes/accessoryComponents.js
+++ b/routes/accessoryComponents.js
@@ -6,11 +6,12 @@ const { buildAccessoryPricing } = require("./accessoryMaterials");
 // Create component link
 router.post('/accessory-components', async (req, res) => {
   try {
-    const { parent_accessory_id, child_accessory_id, quantity } = req.body;
+    const { parent_accessory_id, child_accessory_id, quantity, name } = req.body;
     const link = await AccessoryComponents.createComponentLink(
       parent_accessory_id,
       child_accessory_id,
       quantity,
+      name,
       1
     );
     res.status(201).json(link);

--- a/routes/accessoryMaterials.js
+++ b/routes/accessoryMaterials.js
@@ -4,6 +4,7 @@ const AccessoryComponents = require('../models/accessoryComponentsModel');
 const OwnerCompanies = require('../models/ownerCompaniesModel');
 const router = express.Router();
 const AccessoryPricing = require("../models/accessoryPricingModel");
+const { ensureColumn } = require('../Modules/dbUtils');
 
 const buildAccessoryPricing = async (accessoryId, ownerId = 1) => {
   const owner = await OwnerCompanies.findById(ownerId);
@@ -221,6 +222,10 @@ const applyQuantityTotals = item => {
  */
 router.post('/accessory-materials', async (req, res) => {
   try {
+    await Promise.all([
+      ensureColumn('accessory_materials', 'investment', 'DECIMAL(10,2)'),
+      ensureColumn('accessory_materials', 'descripcion_material', 'VARCHAR(255)')
+    ]);
     if (Array.isArray(req.body.materials)) {
       const { accessory_id, materials } = req.body;
       if (!accessory_id || !materials.length)
@@ -266,7 +271,9 @@ router.post('/accessory-materials', async (req, res) => {
       price,
       quantity,
       width,
-      length
+      length,
+      investment,
+      description
     } = req.body;
     const totals = applyQuantityTotals({ cost, price, quantity });
     const link = await AccessoryMaterials.linkMaterial(
@@ -278,6 +285,8 @@ router.post('/accessory-materials', async (req, res) => {
       quantity,
       width,
       length,
+      investment,
+      description,
       1
     );
     const calculatedCost = await AccessoryMaterials.calculateCost(
@@ -311,6 +320,10 @@ router.get('/accessory-materials', async (req, res) => {
  */
 router.put('/accessory-materials/:id', async (req, res) => {
   try {
+    await Promise.all([
+      ensureColumn('accessory_materials', 'investment', 'DECIMAL(10,2)'),
+      ensureColumn('accessory_materials', 'descripcion_material', 'VARCHAR(255)')
+    ]);
     if (Array.isArray(req.body.materials)) {
       const accessoryId = Number(req.params.id);
       const materials = req.body.materials;
@@ -420,7 +433,9 @@ router.put('/accessory-materials/:id', async (req, res) => {
       totals.price,
       quantity,
       width,
-      length
+      length,
+      investment,
+      description
     );
 
     const ownerId = parseInt(req.query.owner_id || '1', 10);


### PR DESCRIPTION
## Summary
- add DB utilities to create columns on demand
- extend accessory materials model and routes with investment/description fields
- extend accessory component model and routes with child name field
- store markup and totals directly on accessory creation

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865b36feeb8832d97bc4d0d910df888