### PR TITLE
Return full accessory material data

### DIFF
--- a/models/accessoryMaterialsModel.js
+++ b/models/accessoryMaterialsModel.js
@@ -271,6 +271,7 @@ const findMaterialsByAccessory = (accessoryId) => {
       SELECT a.id AS accessory_id, a.name AS accessory_name,
              am.id AS link_id, am.quantity, am.width_m, am.length_m,
              am.costo, am.porcentaje_ganancia, am.precio,
+             am.investment, am.descripcion_material,
              rm.id AS material_id, rm.name AS material_name, rm.description,
              rm.thickness_mm, rm.width_m AS material_width, rm.length_m AS material_length,
              rm.price, rm.material_type_id,

--- a/routes/accessoryMaterials.js
+++ b/routes/accessoryMaterials.js
@@ -470,6 +470,8 @@ router.get('/accessories/:id/materials', async (req, res) => {
       quantity: row.quantity,
       width_m_used: row.width_m,
       length_m_used: row.length_m,
+      investment: row.investment,
+      descripcion_material: row.descripcion_material,
       cost: row.costo,
       profit_percentage: row.porcentaje_ganancia,
       price_override: row.precio


### PR DESCRIPTION
## Summary
- return investment and description fields in accessory material queries
- expose these fields in the accessory materials route output

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865bb0600fc832dac383c548e0dde5d