### PR TITLE
Fix accessory detail retrieval

### DIFF
--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -71,6 +71,8 @@ CREATE TABLE IF NOT EXISTS accessory_components (
     parent_accessory_id INT NOT NULL,
     child_accessory_id INT NOT NULL,
     quantity INT,
+    cost DECIMAL(10,2),
+    price DECIMAL(10,2),
     owner_id INT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -280,3 +282,7 @@ ALTER TABLE owner_companies
 
 ALTER TABLE owner_companies
   ADD COLUMN logo_path VARCHAR(255);
+
+ALTER TABLE accessory_components
+  ADD COLUMN cost DECIMAL(10,2),
+  ADD COLUMN price DECIMAL(10,2);

--- a/models/accessoryMaterialsModel.js
+++ b/models/accessoryMaterialsModel.js
@@ -283,7 +283,11 @@ const findMaterialsByAccessory = (accessoryId) => {
       WHERE a.id = ?`;
     db.query(sql, [accessoryId], (err, rows) => {
       if (err) return reject(err);
-      resolve(rows);
+      const mapped = rows.map(r => ({
+        ...r,
+        porcentaje_ganancia: r.porcentaje_ganancia ?? 0
+      }));
+      resolve(mapped);
     });
   });
 };


### PR DESCRIPTION
## Summary
- allow accessory components to store cost and price
- return pricing and materials with units when fetching an accessory
- keep porcentaje_ganancia non-null
- update routes for creating and updating components
- migrations updated for new component columns

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865bf436104832d8197f0f7e473b2f6