### PR TITLE
Ensure unit field for accessory materials endpoints

### DIFF
--- a/models/accessoryMaterialsModel.js
+++ b/models/accessoryMaterialsModel.js
@@ -204,7 +204,8 @@ const findAccessoriesWithMaterialsCost = () => {
           quantity: row.quantity,
           width_m: row.piece_width,
           length_m: row.piece_length,
-          cost
+          cost,
+          unit: row.unit
         };
       });
       resolve(detailed);
@@ -224,10 +225,12 @@ const findMaterialsCostByAccessory = (accessoryId) => {
       SELECT a.id AS accessory_id, a.name AS accessory_name,
              am.costo, am.quantity, am.width_m AS piece_width, am.length_m AS piece_length,
              rm.id AS material_id, rm.name AS material_name,
-             rm.price, rm.width_m AS material_width, rm.length_m AS material_length
+             rm.price, rm.width_m AS material_width, rm.length_m AS material_length,
+             mt.unit
       FROM accessories a
       JOIN accessory_materials am ON a.id = am.accessory_id
       JOIN raw_materials rm ON rm.id = am.material_id
+      LEFT JOIN material_types mt ON rm.material_type_id = mt.id
       WHERE a.id = ?`;
     db.query(sql, [accessoryId], (err, rows) => {
       if (err) return reject(err);
@@ -275,7 +278,8 @@ const findMaterialsByAccessory = (accessoryId) => {
              rm.id AS material_id, rm.name AS material_name, rm.description,
              rm.thickness_mm, rm.width_m AS material_width, rm.length_m AS material_length,
              rm.price, rm.material_type_id,
-             mt.description AS material_type_description
+             mt.description AS material_type_description,
+             mt.unit AS unit
       FROM accessories a
       JOIN accessory_materials am ON a.id = am.accessory_id
       JOIN raw_materials rm ON rm.id = am.material_id

--- a/routes/accessories.js
+++ b/routes/accessories.js
@@ -197,7 +197,7 @@ router.get('/accessories/:id', async (req, res) => {
     );
     const materials = rawMaterials.map(m => ({
       ...m,
-      unit: m.width_m && m.length_m ? 'm²' : 'unit'
+      unit: m.unit
     }));
     const accessories = await AccessoryComponents.findByParentDetailed(
       accessory.id,

--- a/routes/accessoryMaterials.js
+++ b/routes/accessoryMaterials.js
@@ -34,7 +34,7 @@ const buildAccessoryPricing = async (accessoryId, ownerId = 1) => {
       material_id: m.material_id,
       width: m.width_m,
       length: m.length_m,
-      unit: 'm',
+      unit: m.unit,
       quantity: m.quantity,
       cost,
       price
@@ -474,7 +474,8 @@ router.get('/accessories/:id/materials', async (req, res) => {
       descripcion_material: row.descripcion_material,
       cost: row.costo,
       profit_percentage: row.porcentaje_ganancia,
-      price_override: row.precio
+      price_override: row.precio,
+      unit: row.unit
     }));
     res.json({ accessory_id, accessory_name, materials });
   } catch (error) {
@@ -500,7 +501,8 @@ router.get('/accessories/:id/materials-cost', async (req, res) => {
       quantity: row.quantity,
       width_m: row.width_m,
       length_m: row.length_m,
-      cost: row.cost
+      cost: row.cost,
+      unit: row.unit
     }));
     const total_cost = materials.reduce((sum, m) => sum + m.cost, 0);
     res.json({ accessory_id, accessory_name, total_cost, materials });


### PR DESCRIPTION
## Summary
- include `unit` information from material type in AccessoryMaterials model
- expose `unit` via `/accessories/:id` materials list
- expose `unit` via `/accessories/:id/materials` and `/accessories/:id/materials-cost`

## Testing
- `bash ./run-tests.sh` *(fails: npm 403 when installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6865c21481e8832dad19231c9b3401b6