### PR TITLE
Fix accessory material update

### DIFF
--- a/models/accessoryMaterialsModel.js
+++ b/models/accessoryMaterialsModel.js
@@ -273,11 +273,11 @@ const findMaterialsByAccessory = (accessoryId) => {
     const sql = `
       SELECT a.id AS accessory_id, a.name AS accessory_name,
              am.id AS link_id, am.quantity, am.width_m, am.length_m,
-             am.costo, am.porcentaje_ganancia, am.precio,
+             am.costo, am.porcentaje_ganancia, am.precio, am.precio AS price,
              am.investment, am.descripcion_material,
              rm.id AS material_id, rm.name AS material_name, rm.description,
              rm.thickness_mm, rm.width_m AS material_width, rm.length_m AS material_length,
-             rm.price, rm.material_type_id,
+             rm.price AS material_price, rm.material_type_id,
              mt.description AS material_type_description,
              mt.unit AS unit
       FROM accessories a

--- a/routes/accessoryMaterials.js
+++ b/routes/accessoryMaterials.js
@@ -27,7 +27,12 @@ const buildAccessoryPricing = async (accessoryId, ownerId = 1) => {
       );
     }
     cost = +cost.toFixed(2);
-    const price = +(cost * factor).toFixed(2);
+    let price;
+    if (m.price !== null && m.price !== undefined) {
+      price = +m.price.toFixed(2);
+    } else {
+      price = +(cost * factor).toFixed(2);
+    }
     totalMaterials += price;
     materials.push({
       accessory_id: accessoryId,
@@ -401,7 +406,9 @@ router.put('/accessory-materials/:id', async (req, res) => {
       price: bodyPrice,
       quantity,
       width,
-      length
+      length,
+      investment,
+      description
     } = req.body;
 
     let profit_percentage =
@@ -415,7 +422,7 @@ router.put('/accessory-materials/:id', async (req, res) => {
     if (typeof accessoryId !== 'number' || typeof materialId !== 'number')
       return res.status(400).json({ message: 'Datos incompletos' });
 
-    const numericFields = { cost, profit_percentage, price, quantity, width, length };
+    const numericFields = { cost, profit_percentage, price, quantity, width, length, investment };
     for (const [key, value] of Object.entries(numericFields)) {
       if (value !== undefined && value !== null && typeof value !== 'number')
         return res.status(400).json({ message: `${key} invalido` });
@@ -467,6 +474,7 @@ router.get('/accessories/:id/materials', async (req, res) => {
       width_m: row.material_width,
       length_m: row.material_length,
       price: row.price,
+      material_price: row.material_price,
       quantity: row.quantity,
       width_m_used: row.width_m,
       length_m_used: row.length_m,


### PR DESCRIPTION
## Summary
- include accessory price when building accessory pricing
- expose stored price and base material price in material lists
- update PUT /accessory-materials/:id handler to validate investment field

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865c661ae88832db26b2c28ad4d47bf