### PR TITLE
Fix accessory material cost handling

### DIFF
--- a/routes/accessories.js
+++ b/routes/accessories.js
@@ -8,10 +8,8 @@ const AccessoryPricing = require('../models/accessoryPricingModel');
 const { ensureColumn } = require('../Modules/dbUtils');
 const router = express.Router();
 
+// cost and price are stored as totals so avoid modifying them
 const applyQuantityTotals = item => {
-  const qty = item.quantity != null ? item.quantity : 1;
-  if (item.cost !== undefined && item.cost !== null) item.cost *= qty;
-  if (item.price !== undefined && item.price !== null) item.price *= qty;
   return item;
 };
 

--- a/routes/accessoryMaterials.js
+++ b/routes/accessoryMaterials.js
@@ -86,10 +86,8 @@ const buildAccessoryPricing = async (accessoryId, ownerId = 1) => {
   };
 };
 
+// cost and price already include the quantity so leave them unchanged
 const applyQuantityTotals = item => {
-  const qty = item.quantity != null ? item.quantity : 1;
-  if (item.cost !== undefined && item.cost !== null) item.cost *= qty;
-  if (item.price !== undefined && item.price !== null) item.price *= qty;
   return item;
 };
 


### PR DESCRIPTION
## Summary
- avoid modifying cost and price based on quantity when storing materials

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865cf875eb8832d84792c4e7ec8eb07