### PR TITLE
Implement automatic accessory pricing sync

### DIFF
--- a/models/accessoryMaterialsModel.js
+++ b/models/accessoryMaterialsModel.js
@@ -381,6 +381,22 @@ const deleteLink = (id) => {
 };
 
 /**
+ * Obtiene los IDs de accesorios que utilizan un material dado.
+ * @param {number} materialId - ID del material.
+ * @returns {Promise<number[]>} Lista de IDs de accesorios.
+ */
+const findAccessoryIdsByMaterial = materialId => {
+  return new Promise((resolve, reject) => {
+    const sql =
+      'SELECT DISTINCT accessory_id FROM accessory_materials WHERE material_id = ?';
+    db.query(sql, [materialId], (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows.map(r => r.accessory_id));
+    });
+  });
+};
+
+/**
  * Elimina todas las relaciones de materiales para un accesorio.
  * @param {number} accessoryId - Identificador del accesorio.
  * @returns {Promise<object>} Resultado de la operación.
@@ -410,5 +426,6 @@ module.exports = {
   updateLinkData,
   deleteByAccessory,
   deleteLink,
-  calculateCost
+  calculateCost,
+  findAccessoryIdsByMaterial
 };

--- a/routes/materials.js
+++ b/routes/materials.js
@@ -1,5 +1,7 @@
 const express = require('express');
 const Materials = require('../models/materialsModel');
+const AccessoryMaterials = require('../models/accessoryMaterialsModel');
+const { buildAccessoryPricing } = require('./accessoryMaterials');
 const router = express.Router();
 
 /**
@@ -233,6 +235,12 @@ router.put('/materials/:id', async (req, res) => {
       price,
       material_type_id
     );
+    const accessoryIds = await AccessoryMaterials.findAccessoryIdsByMaterial(
+      req.params.id
+    );
+    for (const accId of accessoryIds) {
+      await buildAccessoryPricing(accId, material.owner_id || 1);
+    }
     res.json({ message: 'Material actualizado' });
   } catch (error) {
     res.status(500).json({ message: error.message });

--- a/test/models.test.js
+++ b/test/models.test.js
@@ -174,5 +174,17 @@ describe('Model logic', () => {
 
     accessoryMaterials.calculateCost = originalCalc;
   });
+
+  it('findAccessoryIdsByMaterial returns ids list', async () => {
+    db.query = (sql, params, callback) => {
+      callback(null, [
+        { accessory_id: 2 },
+        { accessory_id: 3 }
+      ]);
+    };
+
+    const ids = await accessoryMaterials.findAccessoryIdsByMaterial(1);
+    expect(ids).to.deep.equal([2, 3]);
+  });
 });
 


### PR DESCRIPTION
## Summary
- allow querying accessories linked to a material
- update accessories pricing after material changes
- test accessory ID lookup helper

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866957f19e0832dbd029ec146d4f893