### PR TITLE
Update accessory costs when editing material

### DIFF
--- a/routes/materials.js
+++ b/routes/materials.js
@@ -235,6 +235,7 @@ router.put('/materials/:id', async (req, res) => {
       price,
       material_type_id
     );
+    await AccessoryMaterials.updateCostsByMaterial(req.params.id);
     const accessoryIds = await AccessoryMaterials.findAccessoryIdsByMaterial(
       req.params.id
     );


### PR DESCRIPTION
## Summary
- recalculate accessory material costs after editing a raw material
- expose new helper in model and trigger it from material update route

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686697eef9c0832daca723464327e3ac